### PR TITLE
[REFACTOR] #26: refactor login view model

### DIFF
--- a/Projects/Features/OnboardingFeature/Interface/ViewModel/LoginViewModel.swift
+++ b/Projects/Features/OnboardingFeature/Interface/ViewModel/LoginViewModel.swift
@@ -26,8 +26,8 @@ public protocol LoginViewModelInput: KakaoLoginDelegate, AppleLoginDelegate {
 }
 
 public protocol LoginViewModelOutput {
-    var moveHome: PassthroughSubject<Void, Never> { get }
-    var moveSignUp: PassthroughSubject<Void, Never> { get }
+    var moveHome: (() -> Void)? { get set }
+    var moveSignUp: (() -> Void)? { get set }
 }
 
 public protocol LoginViewModel: LoginViewModelInput, LoginViewModelOutput {

--- a/Projects/Features/OnboardingFeature/Sources/ViewController/LoginViewController.swift
+++ b/Projects/Features/OnboardingFeature/Sources/ViewController/LoginViewController.swift
@@ -15,7 +15,7 @@ import AuthenticationServices
 
 class LoginViewController: BaseViewController<BaseHeaderView, LoginView, DefaultOnboardingCoordinator> {
     
-    private let viewModel: any LoginViewModel
+    private var viewModel: any LoginViewModel
     
     init(viewModel: any LoginViewModel){
         self.viewModel = viewModel
@@ -43,19 +43,16 @@ class LoginViewController: BaseViewController<BaseHeaderView, LoginView, Default
     }
     
     override func bind() {
-        viewModel.moveHome
-            .receive(on: RunLoop.main)
-            .sink{ [weak self] _ in
+        viewModel.moveHome = {
+            DispatchQueue.main.async { [weak self] in
                 self?.coordinator?.startHome()
             }
-            .store(in: &cancellables)
-        
-        viewModel.moveSignUp
-            .receive(on: RunLoop.main)
-            .sink{ [weak self] _ in
+        }
+        viewModel.moveSignUp = {
+            DispatchQueue.main.async { [weak self] in
                 self?.coordinator?.startSignUp()
             }
-            .store(in: &cancellables)
+        }
     }
     
     @objc private func startKakaoLogin(){

--- a/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultLoginViewModel.swift
+++ b/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultLoginViewModel.swift
@@ -25,8 +25,8 @@ final class DefaultLoginViewModel: BaseViewModel, LoginViewModel {
         super.init()
     }
     
-    let moveHome: PassthroughSubject<Void, Never> = PassthroughSubject()
-    let moveSignUp: PassthroughSubject<Void, Never> = PassthroughSubject()
+    var moveHome: (() -> Void)?
+    var moveSignUp: (() -> Void)?
     
     @Published private var kakaoUser: (oauthToken: KakaoSDKAuth.OAuthToken?, user: KakaoSDKUser.User?) = (nil, nil)
     
@@ -60,10 +60,10 @@ final class DefaultLoginViewModel: BaseViewModel, LoginViewModel {
                 UserManager.shared.email = self?.kakaoUser.user?.kakaoAccount?.email
 
                 if isNewMember {
-                    self?.moveSignUp.send(())
+                    self?.moveSignUp?()
                 }
                 else {
-                    self?.moveHome.send(())
+                    self?.moveHome?()
                 }
             }
             .store(in: &cancellable)


### PR DESCRIPTION
### #26 move_ 타입 subject에서 closure로 변경
- moveHome과 moveSignUp을 기존에는 combine 프레임워크의 `PassthroughSubject<Void, Never>`를 활용하여 구현하였습니다. 
- moveHome과 moveSignUp은 화면 이동이라는 동작 수행이 목표이지, 데이터 전달이 목적이 아니므로`moveHome.send(())`와 같이 Void를 넘겨주는 것보다 `moveHome()` 처럼 클로저를 실행시키는 것이 코드 이해 측면에서 좋을 것이라 판단했습니다. 
- 화면 이동은 UI와 관련되어 있어 main 스레드에서 동작해야 합니다. DispatchQueue를 활용하여 main 스레드에서 실행될 수 있도록 설정하였습니다. 