### PR TITLE
[FEATURE] #43: implement image version of choice view 

### DIFF
--- a/Projects/ABKit/Resources/Asset.xcassets/Home/choice_image_expand.imageset/Component 1.svg
+++ b/Projects/ABKit/Resources/Asset.xcassets/Home/choice_image_expand.imageset/Component 1.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12Z" fill="black" fill-opacity="0.4"/>
+<path d="M10.3333 7H8C7.44771 7 7 7.44772 7 8V10.3333" stroke="white" stroke-linecap="round"/>
+<path d="M17 10.3333L17 8C17 7.44771 16.5523 7 16 7L13.6667 7" stroke="white" stroke-linecap="round"/>
+<path d="M13.6667 17L16 17C16.5523 17 17 16.5523 17 16L17 13.6667" stroke="white" stroke-linecap="round"/>
+<path d="M7 13.6667L7 16C7 16.5523 7.44772 17 8 17L10.3333 17" stroke="white" stroke-linecap="round"/>
+</svg>

--- a/Projects/ABKit/Resources/Asset.xcassets/Home/choice_image_expand.imageset/Contents.json
+++ b/Projects/ABKit/Resources/Asset.xcassets/Home/choice_image_expand.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Component 1.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Projects/ABKit/Resources/Asset.xcassets/Home/choice_text_expand.imageset/Component 3.svg
+++ b/Projects/ABKit/Resources/Asset.xcassets/Home/choice_text_expand.imageset/Component 3.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12Z" fill="black" fill-opacity="0.4"/>
+<path d="M7 8H17" stroke="white" stroke-linecap="round"/>
+<path d="M7 12H17" stroke="white" stroke-linecap="round"/>
+<path d="M7 16H12" stroke="white" stroke-linecap="round"/>
+</svg>

--- a/Projects/ABKit/Resources/Asset.xcassets/Home/choice_text_expand.imageset/Contents.json
+++ b/Projects/ABKit/Resources/Asset.xcassets/Home/choice_text_expand.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Component 3.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Projects/ABKit/Sources/Utils/Image.swift
+++ b/Projects/ABKit/Sources/Utils/Image.swift
@@ -26,6 +26,9 @@ public struct Image{
     public static let tabGenerateTopic = UIImage.load(name: "tab_generate_topic")
     
     //MARK: Home
+    
+    public static let choiceTextExpand = UIImage.load(name: "choice_text_expand")
+    public static let choiceImageExpand = UIImage.load(name: "choice_image_expand")
     public static let hide = UIImage.load(name: "hide")
     public static let report = UIImage.load(name: "report")
     public static let resetEnable = UIImage.load(name: "reset_enable")

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceCompleteView.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceCompleteView.swift
@@ -14,7 +14,7 @@ import Core
 
 extension HomeTopicCollectionViewCell {
     
-    final class SelectionCompleteView: BaseView {
+    final class ChoiceCompleteView: BaseView {
         
         private let completeTagLabel: PaddingLabel = {
             let label = PaddingLabel(topBottom: 3, leftRight: 13)
@@ -42,7 +42,7 @@ extension HomeTopicCollectionViewCell {
         }()
         
         private let choiceLabel: UILabel = {
-           let label = UILabel()
+            let label = UILabel()
             label.setTypo(Pretendard.black200)
             return label
         }()

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
@@ -1,0 +1,141 @@
+//
+//  ChoiceContent.swift
+//  HomeFeature
+//
+//  Created by 박소윤 on 2023/12/04.
+//  Copyright © 2023 AB. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import ABKit
+import Domain
+import Core
+
+protocol ChoiceContent{
+    init(choice: Choice)
+    var views: [UIView] { get }
+    func setALayout()
+    func setBLayout()
+}
+
+extension ChoiceContent {
+    var visibleWidth: CGFloat {
+        UIScreen.main.bounds.size.width/2 + 7.5 - 55
+    }
+}
+
+extension HomeTopicCollectionViewCell {
+    
+    final class TextChoiceContent: ChoiceContent {
+        
+        var views: [UIView] {
+            [contentLabel]
+        }
+        
+        private let choice: Choice
+        
+        init(choice: Choice) {
+            self.choice = choice
+            contentLabel.text = choice.content.text
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        private let contentLabel: UILabel = {
+            let label = UILabel()
+            label.setTypo(Pretendard.semibold20)
+            label.textColor = Color.white
+            label.numberOfLines = 0
+            label.lineBreakMode = .byWordWrapping
+            return label
+        }()
+        
+        func setALayout() {
+            contentLabel.snp.makeConstraints{
+                $0.centerY.centerX.equalToSuperview()
+                $0.leading.equalTo(visibleWidth+44)
+                $0.trailing.equalToSuperview().inset(44)
+            }
+        }
+        
+        func setBLayout() {
+            contentLabel.snp.makeConstraints{
+                $0.centerY.centerX.equalToSuperview()
+                $0.leading.equalToSuperview().inset(44)
+                $0.trailing.equalToSuperview().inset(visibleWidth+44)
+            }
+        }
+    }
+    
+    final class ImageChoiceContent: ChoiceContent {
+        
+        var views: [UIView] {
+            [buttonStackView, imageView]
+        }
+        
+        private let choice: Choice
+        
+        init(choice: Choice) {
+            self.choice = choice
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        private let imageView: UIImageView = {
+            let imageView = UIImageView()
+            imageView.backgroundColor = Color.black
+            imageView.layer.cornerRadius = 136/2
+            imageView.snp.makeConstraints{
+                $0.width.height.equalTo(136)
+            }
+            return imageView
+        }()
+        
+        private lazy var buttonStackView: UIStackView = {
+            let stackView = UIStackView(axis: .vertical, spacing: 4)
+            stackView.addArrangedSubviews([textExpandButton, imageExpandButton])
+            return stackView
+        }()
+        private let textExpandButton: UIButton = {
+            let button = UIButton()
+            button.setImage(Image.choiceTextExpand, for: .normal)
+            button.snp.makeConstraints{
+                $0.width.height.equalTo(24)
+            }
+            return button
+        }()
+        private let imageExpandButton: UIButton = {
+            let button = UIButton()
+            button.setImage(Image.choiceImageExpand, for: .normal)
+            button.snp.makeConstraints{
+                $0.width.height.equalTo(24)
+            }
+            return button
+        }()
+        
+        func setALayout() {
+            buttonStackView.snp.makeConstraints{
+                $0.top.equalToSuperview().offset(6)
+                $0.leading.equalToSuperview().offset(visibleWidth+6)
+            }
+            imageView.snp.makeConstraints{
+                $0.top.bottom.trailing.equalToSuperview().inset(6)
+            }
+        }
+        
+        func setBLayout() {
+            buttonStackView.snp.makeConstraints{
+                $0.top.equalToSuperview().offset(6)
+                $0.trailing.equalToSuperview().inset(visibleWidth+6)
+            }
+            imageView.snp.makeConstraints{
+                $0.top.bottom.leading.equalToSuperview().inset(6)
+            }
+        }
+    }
+}

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceView.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceView.swift
@@ -9,15 +9,16 @@
 import UIKit
 import ABKit
 import Core
+import Domain
 
 extension HomeTopicCollectionViewCell {
-
-    final class ChoiceView: BaseView {
+    
+    class ChoiceView: BaseView {
         
-        private let choice: ChoiceOption
+        private let option: ChoiceOption
         
-        init(choice: ChoiceOption){
-            self.choice = choice
+        init(option: ChoiceOption) {
+            self.option = option
             super.init()
         }
         
@@ -25,60 +26,86 @@ extension HomeTopicCollectionViewCell {
             fatalError("init(coder:) has not been implemented")
         }
         
-        private let choiceLabel: UILabel = {
+        private var content: ChoiceContent?
+        
+        private let optionLabel: UILabel = {
             let label = UILabel()
+            label.textAlignment = .center
             label.textColor = Color.white20
             label.setTypo(Pretendard.black200)
             return label
         }()
         
-        let contentLabel: UILabel = {
-            let label = UILabel()
-            label.setTypo(Pretendard.semibold20)
-            label.textColor = Color.white
-            label.numberOfLines = 0
-            label.lineBreakMode = .byWordWrapping
-            return label
-        }()
-        
         override func style() {
-            choiceLabel.text = choice.title
-            contentLabel.textAlignment = choice.textAlignment
-            backgroundColor = choice.backgroundColor
+            backgroundColor = option.backgroundColor
             layer.cornerRadius = 148/2
-            layer.maskedCorners = choice.cornerRadiusPosition
+            layer.maskedCorners = option.cornerRadiusPosition
             layer.masksToBounds = true
         }
         
         override func hierarchy() {
-            addSubviews([choiceLabel, contentLabel])
+            addSubviews([optionLabel])
         }
         
         override func layout() {
+            
             self.snp.makeConstraints{
+                $0.width.equalTo(UIScreen.main.bounds.size.width-55)
                 $0.height.equalTo(148)
             }
-            contentLabel.snp.makeConstraints{
-                $0.centerY.centerX.equalToSuperview()
-                $0.leading.equalToSuperview().inset(44)
+            
+            setOptionLabelLayout()
+            
+            func setOptionLabelLayout() {
+                switch option {
+                case .A:
+                    optionLabel.snp.makeConstraints{
+                        $0.centerY.equalToSuperview().offset(20)
+                        $0.leading.equalToSuperview().offset(71)
+                        $0.trailing.equalToSuperview().offset(-95)
+                    }
+                case .B:
+                    optionLabel.snp.makeConstraints{
+                        $0.centerY.equalToSuperview().offset(20)
+                        $0.leading.equalToSuperview().offset(107)
+                        $0.trailing.equalToSuperview().offset(-83)
+                    }
+                }
             }
-            choice == .A ? setALayout() : setBLayout()
         }
         
-        private func setALayout(){
-            choiceLabel.snp.makeConstraints{
-                $0.centerY.equalToSuperview().offset(20)
-                $0.leading.equalToSuperview().offset(-69)
-            }
+        override func initialize() {
+            optionLabel.text = option.title
         }
         
-        private func setBLayout(){
-            choiceLabel.snp.makeConstraints{
-                $0.centerY.equalToSuperview().offset(20)
-                $0.trailing.equalToSuperview().offset(57)
+        func fill(_ choice: Choice) {
+            
+            content = {
+                if choice.content.imageURL == nil {
+                    return TextChoiceContent(choice: choice)
+                }
+                else {
+                    return ImageChoiceContent(choice: choice)
+                }
+            }()
+            
+            setContentLayout()
+            
+            func setContentLayout(){
+                
+                guard let content = content else { return }
+                addSubviews(content.views)
+                
+                switch option {
+                case .A:
+                    content.setALayout()
+                case .B:
+                    content.setBLayout()
+                }
             }
         }
     }
+    
 }
     
 fileprivate extension ChoiceOption {

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -19,10 +19,10 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     weak var delegate: TopicBottomSheetDelegate?
     private var cancellable: Set<AnyCancellable> = []
     
-    private let topic: TopicGroup = TopicGroup()
-    private let user: UserGroup = UserGroup()
-    private let selection: SelectionGroup = SelectionGroup()
-    private let etc: EtcGroup = EtcGroup()
+    private let topicGroup: TopicGroup = TopicGroup()
+    private let userGroup: UserGroup = UserGroup()
+    private let choiceGroup: ChoiceGroup = ChoiceGroup()
+    private let etcGroup: EtcGroup = EtcGroup()
     private let chat: ChatView = ChatView()
     
     private let profileStackView: UIStackView = UIStackView(axis: .horizontal, spacing: 8)
@@ -31,62 +31,62 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     
     override func hierarchy() {
 
-        baseView.addSubviews([etc.realTimeTitleLabel, topic.titleLabel, profileStackView, choiceStackView, selection.completeView, topic.timer, selection.slideExplainView, informationStackView, etc.declareButton, chat])
+        baseView.addSubviews([etcGroup.realTimeTitleLabel, topicGroup.titleLabel, profileStackView, choiceStackView, choiceGroup.completeView, topicGroup.timer, choiceGroup.slideExplainView, informationStackView, etcGroup.declareButton, chat])
         
-        profileStackView.addArrangedSubviews([user.profileImageView, user.nicknameLabel])
+        profileStackView.addArrangedSubviews([userGroup.profileImageView, userGroup.nicknameLabel])
         
-        choiceStackView.addArrangedSubviews([selection.aChoiceView, selection.bChoiceView])
+        choiceStackView.addArrangedSubviews([choiceGroup.aChoiceView, choiceGroup.bChoiceView])
 
-        informationStackView.addArrangedSubviews([topic.sideLabel, etc.separatorLine, topic.keywordLabel])
+        informationStackView.addArrangedSubviews([topicGroup.sideLabel, etcGroup.separatorLine, topicGroup.keywordLabel])
     }
     
     override func layout() {
         
-        etc.realTimeTitleLabel.snp.makeConstraints{
+        etcGroup.realTimeTitleLabel.snp.makeConstraints{
             $0.top.centerX.equalToSuperview()
         }
         
-        topic.titleLabel.snp.makeConstraints{
-            $0.top.equalTo(etc.realTimeTitleLabel.snp.bottom).offset(20)
+        topicGroup.titleLabel.snp.makeConstraints{
+            $0.top.equalTo(etcGroup.realTimeTitleLabel.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.leading.equalToSuperview().offset(102)
         }
         
         profileStackView.snp.makeConstraints{
-            $0.top.equalTo(topic.titleLabel.snp.bottom).offset(4)
+            $0.top.equalTo(topicGroup.titleLabel.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
         }
         
         choiceStackView.snp.makeConstraints{
             $0.top.equalTo(profileStackView.snp.bottom).offset(56)
-            $0.leading.trailing.equalToSuperview()
+            $0.centerX.equalToSuperview()
         }
         
-        selection.aChoiceView.snp.makeConstraints{
-            $0.width.equalTo(selection.bChoiceView)
+        choiceGroup.aChoiceView.snp.makeConstraints{
+            $0.width.equalTo(choiceGroup.bChoiceView)
         }
         
-        selection.completeView.snp.makeConstraints{
+        choiceGroup.completeView.snp.makeConstraints{
             $0.top.equalTo(profileStackView.snp.bottom).offset(42)
             $0.leading.trailing.equalToSuperview().inset(28)
         }
 
-        topic.timer.snp.makeConstraints{
+        topicGroup.timer.snp.makeConstraints{
             $0.top.equalTo(choiceStackView.snp.bottom).offset(43)
             $0.centerX.equalToSuperview()
         }
         
-        selection.slideExplainView.snp.makeConstraints{
-            $0.top.equalTo(topic.timer.snp.bottom).offset(4)
+        choiceGroup.slideExplainView.snp.makeConstraints{
+            $0.top.equalTo(topicGroup.timer.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
         }
         
         informationStackView.snp.makeConstraints{
-            $0.top.equalTo(selection.slideExplainView.snp.bottom).offset(43)
+            $0.top.equalTo(choiceGroup.slideExplainView.snp.bottom).offset(43)
             $0.leading.equalToSuperview().offset(20)
         }
         
-        etc.declareButton.snp.makeConstraints{
+        etcGroup.declareButton.snp.makeConstraints{
             $0.trailing.equalToSuperview().inset(20)
             $0.centerY.equalTo(informationStackView)
         }
@@ -98,7 +98,7 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     }
     
     override func initialize() {
-        etc.declareButton.tapPublisher
+        etcGroup.declareButton.tapPublisher
             .sink{ [weak self] _ in
                 self?.delegate?.show()
             }
@@ -111,27 +111,27 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
             select(choice: choice)
         }
         else {
-            selection.completeView.isHidden = true
-            selection.aChoiceView.contentLabel.text = data.aOption.content.text
-            selection.bChoiceView.contentLabel.text = data.bOption.content.text
+            choiceGroup.completeView.isHidden = true
+            choiceGroup.aChoiceView.fill(data.aOption)
+            choiceGroup.bChoiceView.fill(data.bOption)
         }
         
-        topic.titleLabel.text = data.title
-        topic.sideLabel.text = data.side
-        topic.keywordLabel.text = data.keyword
-        user.nicknameLabel.text = data.nickname
+        topicGroup.titleLabel.text = data.title
+        topicGroup.sideLabel.text = data.side
+        topicGroup.keywordLabel.text = data.keyword
+        userGroup.nicknameLabel.text = data.nickname
         chat.chatCountFrame.binding(data.chatCount)
         chat.likeCountFrame.binding(data.likeCount)
     }
     
     func binding(timer: TimerInfo) {
-        topic.timer.binding(data: timer)
+        topicGroup.timer.binding(data: timer)
     }
     
     func select(choice: Choice){
-        selection.completeView.fill(choice: choice)
-        selection.completeView.isHidden = false
-        selection.slideExplainView.isHidden = true
+        choiceGroup.completeView.fill(choice: choice)
+        choiceGroup.completeView.isHidden = false
+        choiceGroup.slideExplainView.isHidden = true
         choiceStackView.isHidden = true
         chat.canUserInteraction = true
         
@@ -187,8 +187,8 @@ extension HomeTopicCollectionViewCell {
         }()
     }
     
-    final class SelectionGroup {
-        let completeView: SelectionCompleteView = SelectionCompleteView()
+    final class ChoiceGroup {
+        let completeView: ChoiceCompleteView = ChoiceCompleteView()
         let aChoiceView = ChoiceView(option: .A)
         let bChoiceView = ChoiceView(option: .B)
         lazy var slideExplainView: UIView = {

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -189,8 +189,8 @@ extension HomeTopicCollectionViewCell {
     
     final class SelectionGroup {
         let completeView: SelectionCompleteView = SelectionCompleteView()
-        let aChoiceView = ChoiceView(choice: .A)
-        let bChoiceView = ChoiceView(choice: .B)
+        let aChoiceView = ChoiceView(option: .A)
+        let bChoiceView = ChoiceView(option: .B)
         lazy var slideExplainView: UIView = {
             let view = UIView()
             view.addSubviews([leftSlideImageView, rightSlideImageView, slideExplainLabel])

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -143,6 +143,15 @@ extension HomeTabViewController: UICollectionViewDelegate, UICollectionViewDataS
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         currentTopicCell = cell as? HomeTopicCollectionViewCell
     }
+    
+    // clipsToBounds를 활용하여 토픽 전환(scroll)시 선택지 뷰가 셀 자체 크기를 넘기지 못하도록 한다.
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        currentTopicCell?.clipsToBounds = true
+    }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        currentTopicCell?.clipsToBounds = false
+    }
 }
 
 extension HomeTabViewController: TopicBottomSheetDelegate {


### PR DESCRIPTION
### 이미지 버전의 선택 뷰 구현
- 이미지인 경우와 텍스트인 경우를 분리하기 위해 ChoiceView에서 contentLabel을 제거하였습니다. 
- 각 선택지의 컨텐츠 설정을 도와줄 ChoiceContent 프로토콜을 선언했습니다. 
- ChoiceContent에서는 A, B 선택지의 컨텐츠 관련 뷰들을 views에 담아주고, 레이아웃을 각각의 메서드에 구현해줍니다.
- ChoiceView에서 ChoiceContent의 컨텐츠 뷰들을 자식으로 추가하고, 선택지에 맞는 레이아웃 설정 메서드가 호출되도록 설계 및 구현하였습니다.

### 토픽 전환시 선택 뷰의 영역 침범 문제 해결
- view controller에서 clipsToBounds를 활용하여 토픽 전환 스크롤이 진행되는 동안 cell 밖으로 영역이 넘어가지 못하도록 코드를 추가하였습니다. 

---
close #43