### PR TITLE
[DESIGN] #69: update text version choice view layout

### DIFF
--- a/Projects/ABKit/Sources/Utils/Font/PretendardTypo.swift
+++ b/Projects/ABKit/Sources/Utils/Font/PretendardTypo.swift
@@ -27,6 +27,7 @@ public enum Pretendard {
 
     public static let semibold13: TypoCase = SemiBold13()
     public static let semibold14: TypoCase = SemiBold14()
+    public static let semibold16: TypoCase = SemiBold16()
     public static let semibold18: TypoCase = SemiBold18()
     public static let semibold20: TypoCase = SemiBold20()
     public static let semibold24: TypoCase = SemiBold24()
@@ -106,6 +107,11 @@ extension Pretendard{
     
     struct SemiBold14: TypoCase {
         let font: UIFont = ABKitFontFamily.Pretendard.semiBold.font(size: 14)
+        let lineHeight: CGFloat? = nil
+    }
+    
+    struct SemiBold16: TypoCase {
+        let font: UIFont = ABKitFontFamily.Pretendard.semiBold.font(size: 16)
         let lineHeight: CGFloat? = nil
     }
     

--- a/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
@@ -10,6 +10,15 @@ import Foundation
 import Domain
 
 public struct CommentListItemViewModel {
+    
+    public init() {
+        self.profileImageUrl = URL(string: "http://ab.")!
+        self.nickname = "닉네임닉네임"
+        self.date = "2일전" //comment.date
+        self.choice = "A. 일이삼사오육칠팔구십일이삼사오육칠팔구십" //comment.choice
+        self.content = "왜들 그리 다운돼있어? 뭐가 문제야 say something 분위기가 겁나 싸해 요새는 이런 게 유행인가 왜들 그리 재미없어? 아 그건 나도 마찬가지"
+        self.likeCount = String(129)
+    }
 
     public init(
         comment: Comment

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
@@ -38,35 +38,40 @@ extension HomeTopicCollectionViewCell {
         
         init(choice: Choice) {
             self.choice = choice
-            contentLabel.text = choice.content.text
         }
         
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
         
-        private let contentLabel: UILabel = {
+        private lazy var contentLabel: UILabel = {
             let label = UILabel()
-            label.setTypo(Pretendard.semibold20, setLineSpacing: true)
+            label.text = choice.content.text
+            let typo = label.text!.count > 20 ? Pretendard.semibold16 : Pretendard.semibold20
+            label.setTypo(typo, setLineSpacing: true)
             label.textColor = Color.white
             label.numberOfLines = 0
-            label.lineBreakMode = .byWordWrapping
+            label.textAlignment = .center
             return label
         }()
         
         func setALayout() {
             contentLabel.snp.makeConstraints{
+                $0.width.equalTo(87)
+                $0.top.equalToSuperview().offset(19)
                 $0.centerY.centerX.equalToSuperview()
                 $0.leading.equalTo(visibleWidth+44)
-                $0.trailing.equalToSuperview().inset(44)
+                $0.trailing.equalToSuperview().inset(49)
             }
         }
         
         func setBLayout() {
             contentLabel.snp.makeConstraints{
+                $0.width.equalTo(87)
+                $0.top.equalToSuperview().offset(19)
                 $0.centerY.centerX.equalToSuperview()
                 $0.leading.equalToSuperview().inset(44)
-                $0.trailing.equalToSuperview().inset(visibleWidth+44)
+                $0.trailing.equalToSuperview().inset(visibleWidth+49)
             }
         }
     }
@@ -126,7 +131,6 @@ extension HomeTopicCollectionViewCell {
                 .post(
                     name: NSNotification.Name(Topic.Action.expandImage.identifier),
                     object: self,
-                    //TODO: #55 이후 키값 변경 예정
                     userInfo: [Choice.identifier: choice]
                 )
         }

--- a/Projects/Features/HomeFeature/Sources/ViewController/CommentBottomSheetViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/CommentBottomSheetViewController.swift
@@ -84,6 +84,7 @@ final class CommentBottomSheetViewController: UIViewController {
     func bind() {
         viewModel.reloadData = {
             DispatchQueue.main.async {
+                self.headerView.fill(self.viewModel.commentsCount)
                 self.tableView.reloadData()
             }
         }

--- a/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
@@ -53,7 +53,9 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
                 if result.isSuccess, let (pageInfo, data) = result.data {
                     //TODO: 페이징 코드 추가
                     self.pageInfo = pageInfo
-                    self.comments.append(contentsOf: data.map{ .init(comment: $0) })
+                    self.comments = [CommentListItemViewModel](repeating: .init(), count: 10)
+//                    self.comments.append(contentsOf: data.map{ _ in .init() })
+                    self.reloadData?()
                 }
                 else if let error = result.error {
                     self.errorHandler.send(error)


### PR DESCRIPTION
### 텍스트 버전의 ChoiceView 레이아웃 업데이트
- label의 너비를 고정시키고, 글자 수에 따라 폰트를 다르게 설정합니다. 

### 댓글 바텀시트
- 회의 때 UI 시연을 위해 테스트 데이터를 추가하였습니다.
- 이전에 구현할 때, 놓쳤던 코드들을 추가하였습니다.
    - 댓글 조회 API 이후 reloadData 클로저를 호출합니다. 
    - reloadData  클로저 내에서 header view의 댓글 갯수도 리프레시 될 수 있도록 코드를 추가하였습니다. 
 
---
close #69