### PR TITLE
[DESIGN] #90: 토픽 선택지 선택 완료 애니메이션 페이드 아웃 적용

### DIFF
--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceContent.swift
@@ -20,12 +20,6 @@ protocol ChoiceContent{
     func setBLayout()
 }
 
-extension ChoiceContent {
-    var visibleWidth: CGFloat {
-        UIScreen.main.bounds.size.width/2 + 7.5 - 55
-    }
-}
-
 extension HomeTopicCollectionViewCell {
     
     final class TextChoiceContent: ChoiceContent {
@@ -60,7 +54,7 @@ extension HomeTopicCollectionViewCell {
                 $0.width.equalTo(87)
                 $0.top.equalToSuperview().offset(19)
                 $0.centerY.centerX.equalToSuperview()
-                $0.leading.equalTo(visibleWidth+44)
+                $0.leading.equalTo(ChoiceView.unvisibleWidth+44)
                 $0.trailing.equalToSuperview().inset(49)
             }
         }
@@ -71,7 +65,7 @@ extension HomeTopicCollectionViewCell {
                 $0.top.equalToSuperview().offset(19)
                 $0.centerY.centerX.equalToSuperview()
                 $0.leading.equalToSuperview().inset(44)
-                $0.trailing.equalToSuperview().inset(visibleWidth+49)
+                $0.trailing.equalToSuperview().inset(ChoiceView.unvisibleWidth+49)
             }
         }
     }
@@ -138,7 +132,7 @@ extension HomeTopicCollectionViewCell {
         func setALayout() {
             buttonStackView.snp.makeConstraints{
                 $0.top.equalToSuperview().offset(6)
-                $0.leading.equalToSuperview().offset(visibleWidth+6)
+                $0.leading.equalToSuperview().offset(ChoiceView.unvisibleWidth+6)
             }
             imageView.snp.makeConstraints{
                 $0.top.bottom.trailing.equalToSuperview().inset(6)
@@ -148,7 +142,7 @@ extension HomeTopicCollectionViewCell {
         func setBLayout() {
             buttonStackView.snp.makeConstraints{
                 $0.top.equalToSuperview().offset(6)
-                $0.trailing.equalToSuperview().inset(visibleWidth+6)
+                $0.trailing.equalToSuperview().inset(ChoiceView.unvisibleWidth+6)
             }
             imageView.snp.makeConstraints{
                 $0.top.bottom.leading.equalToSuperview().inset(6)

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceView.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/Frame/ChoiceView.swift
@@ -14,6 +14,12 @@ extension HomeTopicCollectionViewCell {
     
     class ChoiceView: BaseView {
         
+        static let spacing: CGFloat = 15
+        static let extraWidth: CGFloat = 100
+        static let unvisibleWidth: CGFloat = Device.width + extraWidth
+        static let visibleWidth: CGFloat = (Device.width-15)/2
+        static let width: CGFloat = unvisibleWidth + visibleWidth
+        
         private let option: Choice.Option
         
         init(option: Choice.Option) {
@@ -54,7 +60,7 @@ extension HomeTopicCollectionViewCell {
         override func layout() {
             
             self.snp.makeConstraints{
-                $0.width.equalTo(Device.width-55)
+                $0.width.equalTo(ChoiceView.width)
                 $0.height.equalTo(148)
             }
 
@@ -64,7 +70,7 @@ extension HomeTopicCollectionViewCell {
             func setGradient() {
                 gradientLayer.frame = CGRect(
                     x: 0, y: 0,
-                    width: Device.width-55, height: 148
+                    width: ChoiceView.width, height: 148
                 )
                 layer.addSublayer(gradientLayer)
                 bringSubviewToFront(optionLabel)
@@ -75,14 +81,12 @@ extension HomeTopicCollectionViewCell {
                 case .A:
                     optionLabel.snp.makeConstraints{
                         $0.centerY.equalToSuperview().offset(20)
-                        $0.leading.equalToSuperview().offset(71)
-                        $0.trailing.equalToSuperview().offset(-95)
+                        $0.trailing.equalToSuperview().inset((Device.width-15)/2-85)
                     }
                 case .B:
                     optionLabel.snp.makeConstraints{
                         $0.centerY.equalToSuperview().offset(20)
-                        $0.leading.equalToSuperview().offset(107)
-                        $0.trailing.equalToSuperview().offset(-83)
+                        $0.leading.equalToSuperview().offset((Device.width-15)/2-77)
                     }
                 }
             }

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -163,25 +163,35 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
                 }
             }
         case .ended:
-            
             let (option, movePoint): (Choice.Option?, CGPoint) = {
                 switch state {
                 case .normal:
                     return (nil, originalPoint)
                 case .choiceA:
-                    return (.A, CGPoint(x: Device.width, y: originalPoint.y))
+                    return (.A, CGPoint(x: 0, y: originalPoint.y))
                 case .choiceB:
-                    return (.B, CGPoint(x: -2*Device.width, y: originalPoint.y))
+                    return (.B, CGPoint(x: -(ChoiceView.width+ChoiceView.visibleWidth+ChoiceView.extraWidth+ChoiceView.spacing), y: originalPoint.y))
                 }
             }()
             
             UIView.animate(
-                withDuration: 0.5,
+                withDuration: 0.4,
                 animations: {
                     self.choiceStackView.frame.origin = movePoint
+                }
+            )
+            
+            guard let option = option else { return }
+            UIView.animate(
+                withDuration: 0.6,
+                delay: 0.3,
+                animations: {
+                self.choiceStackView.alpha = 0
                 },
                 completion: { _ in
-                    guard let option = option else { return }
+                    self.choiceStackView.isHidden = true
+                    self.choiceStackView.center.x = self.center.x
+                    self.choiceStackView.alpha = 1
                     self.delegate?.vote(choice: option)
                 }
             )


### PR DESCRIPTION
### 토픽 선택지 선택 완료 애니메이션 페이드 아웃 적용
-  선택지의 가로 길이를 조정하였습니다. 
- 옵션 레이블이 지나간 이후부터는 페이드 아웃을 적용시켰습니다. 

---
close #90