### PR TITLE
[FEATURE] #82: 댓글 바텀시트 애니메이션 구현

### DIFF
--- a/Projects/Features/HomeFeature/Interface/HomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Interface/HomeCoordinator.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2023 AB. All rights reserved.
 //
 
+import Foundation
 import FeatureDependency
 import Domain
 
 public protocol HomeCoordinator: Coordinator {
     func startTopicBottomSheet()
-    func startCommentBottomSheet(topicId: Int)
+    func startCommentBottomSheet(standard: CGFloat, topicId: Int)
     func startImagePopUp(choice: Choice)
     func startWritersBottomSheet(index: Int)
     func startOthersBottomSheet(index: Int)

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -241,6 +241,10 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
         
         chat.canUserInteraction = value
     }
+    
+    func standardOfCommentBottomSheetNormalState() -> UIView{
+        profileStackView
+    }
 }
 
 extension HomeTopicCollectionViewCell {

--- a/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
@@ -71,6 +71,7 @@ public class DefaultHomeCoordinator: HomeCoordinator {
         
         commentBottomSheet = CommentBottomSheetViewController(viewModel: viewModel())
         commentBottomSheet?.coordinator = self
+        commentBottomSheet?.modalPresentationStyle = .custom
         if let commentBottomSheet = commentBottomSheet {
             navigationController.present(commentBottomSheet, animated: true)
         }

--- a/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
@@ -67,9 +67,9 @@ public class DefaultHomeCoordinator: HomeCoordinator {
         navigationController.present(TopicBottomSheetViewController(viewModel: homeViewModel), animated: true)
     }
     
-    public func startCommentBottomSheet(topicId: Int) {
+    public func startCommentBottomSheet(standard: CGFloat, topicId: Int) {
         
-        commentBottomSheet = CommentBottomSheetViewController(viewModel: viewModel())
+        commentBottomSheet = CommentBottomSheetViewController(standard: standard, viewModel: viewModel())
         commentBottomSheet?.coordinator = self
         commentBottomSheet?.modalPresentationStyle = .custom
         if let commentBottomSheet = commentBottomSheet {

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -192,10 +192,18 @@ extension HomeTabViewController: ChatBottomSheetDelegate, TopicBottomSheetDelega
         case Topic.Action.showBottomSheet.identifier:
             coordinator?.startTopicBottomSheet()
         case Comment.Action.showBottomSheet.identifier:
-            coordinator?.startCommentBottomSheet(topicId: viewModel.currentTopic.id)
+            coordinator?
+                .startCommentBottomSheet(
+                    standard: standardOfCommentBottomSheet(),
+                    topicId: viewModel.currentTopic.id
+                )
         default:
             return
         }
+    }
+    
+    private func standardOfCommentBottomSheet() -> CGFloat {
+        view.convert((currentTopicCell?.standardOfCommentBottomSheetNormalState().frame)!, from: currentTopicCell).maxY
     }
 }
 


### PR DESCRIPTION
### 댓글 바텀시트 애니메이션 구현
- 애플에서 제공하는 sheetPresentationController를 사용하지 않고, 직접 구현하였습니다. 

### 댓글 바텀시트 높이 조정
- 토픽 셀에 속한 프로필 이미지를 기준으로 offset 값을 적용하여 디바이스마다 다른 위치로 등장하던 문제를 해결하였습니다. 

---
close #82 
close #92 