### PR TITLE
[FIX] #96: 투표 실패할 경우 선택지 다시 보여주기

### DIFF
--- a/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
@@ -25,7 +25,8 @@ public protocol TopicBottomSheetViewModel {
 }
 
 public protocol TopicVoteViewModel {
-    var voteSuccess: AnyPublisher<Choice, Never> { get }
+    var successVote: AnyPublisher<Choice, Never> { get }
+    var failVote: PassthroughSubject<Void, Never> { get }
     func vote(choice: Choice.Option)
 }
 

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -188,10 +188,9 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
                 animations: {
                 self.choiceStackView.alpha = 0
                 },
-                completion: { _ in
-                    self.choiceStackView.isHidden = true
-                    self.choiceStackView.center.x = self.center.x
-                    self.choiceStackView.alpha = 1
+                completion: { [weak self] _ in
+                    guard let self = self else { return }
+                    self.initializeChoiceView()
                     self.delegate?.vote(choice: option)
                 }
             )
@@ -199,8 +198,10 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
         }
     }
     
-    func moveChoicesOriginalPosition() {
-        choiceStackView.frame.origin = originalPoint
+    private func initializeChoiceView() {
+        choiceStackView.isHidden = true
+        choiceStackView.center.x = center.x
+        choiceStackView.alpha = 1
     }
     
     func binding(data: HomeTopicItemViewModel) {
@@ -244,6 +245,10 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     
     func standardOfCommentBottomSheetNormalState() -> UIView{
         profileStackView
+    }
+    
+    func failVote() {
+        choiceStackView.isHidden = false
     }
 }
 

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/HomeTopicCollectionViewCell.swift
@@ -19,6 +19,15 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     weak var delegate: (VoteDelegate & TopicBottomSheetDelegate & ChatBottomSheetDelegate)?
     private var cancellable: Set<AnyCancellable> = []
     
+    // 스와이프 제스처 관련 프로퍼티
+    private enum SwipeState {
+        case choiceA
+        case choiceB
+        case normal
+    }
+    private var state: SwipeState = .normal
+    private var originalPoint: CGPoint = CGPoint()
+    
     private let topicGroup: TopicGroup = TopicGroup()
     private let userGroup: UserGroup = UserGroup()
     private let choiceGroup: ChoiceGroup = ChoiceGroup()
@@ -111,15 +120,18 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
     }
     
     override func initialize() {
-        
-        etcGroup.etcButton.tapPublisher
-            .sink{ [weak self] _ in
-                self?.delegate?.show(DelegateSender(identifier: Topic.Action.showBottomSheet.identifier))
-            }
-            .store(in: &cancellable)
-        
+
+        addTarget()
         addTapGesture()
         addPanGesture()
+        
+        func addTarget(){
+            etcGroup.etcButton.tapPublisher
+                .sink{ [weak self] _ in
+                    self?.delegate?.show(DelegateSender(identifier: Topic.Action.showBottomSheet.identifier))
+                }
+                .store(in: &cancellable)
+        }
         
         func addTapGesture() {
             chat.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(chatTapGesture)))
@@ -137,32 +149,42 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
         delegate?.show(DelegateSender(identifier: Comment.Action.showBottomSheet.identifier))
     }
     
-    enum SwipeState {
-        case choiceA
-        case choiceB
-        case normal
-    }
-    
-    private var originalPoint: CGPoint = CGPoint()
-    private var state: SwipeState = .normal
-    
     @objc private func panGesture(_ recognizer: UIPanGestureRecognizer) {
+        
         let translation = recognizer.translation(in: choiceStackView)
+        
         switch recognizer.state {
+            
         case .began:
-            state = .normal
-            originalPoint = choiceStackView.frame.origin
+            
+            initializeState()
+            
+            func initializeState() {
+                state = .normal
+                originalPoint = choiceStackView.frame.origin
+            }
+            
         case .changed:
-            choiceStackView.frame.origin = CGPoint(x: originalPoint.x + translation.x, y: originalPoint.y)
-            if abs(translation.x) >= Device.width/2 {
-                if state == .normal && translation.x <= 0{
-                    state = .choiceB
-                }
-                else if state == .normal && translation.x >= 0{
-                    state = .choiceA
+            
+            moveChoiceView()
+            changeState()
+            
+            func moveChoiceView() {
+                choiceStackView.frame.origin = CGPoint(x: originalPoint.x + translation.x, y: originalPoint.y)
+            }
+            
+            func changeState() {
+                if abs(translation.x) >= Device.width/2 {
+                    if state == .normal && translation.x <= 0{
+                        state = .choiceB
+                    }
+                    else if state == .normal && translation.x >= 0{
+                        state = .choiceA
+                    }
                 }
             }
         case .ended:
+            
             let (option, movePoint): (Choice.Option?, CGPoint) = {
                 switch state {
                 case .normal:
@@ -174,34 +196,54 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
                 }
             }()
             
-            UIView.animate(
-                withDuration: 0.4,
-                animations: {
-                    self.choiceStackView.frame.origin = movePoint
-                }
-            )
+            startVoteAnimate()
+            startFadeAnimation()
             
-            guard let option = option else { return }
-            UIView.animate(
-                withDuration: 0.6,
-                delay: 0.3,
-                animations: {
-                self.choiceStackView.alpha = 0
-                },
-                completion: { [weak self] _ in
-                    guard let self = self else { return }
-                    self.initializeChoiceView()
-                    self.delegate?.vote(choice: option)
+            func startVoteAnimate() {
+                UIView.animate(
+                    withDuration: 0.4,
+                    animations: {
+                        self.choiceStackView.frame.origin = movePoint
+                    }
+                )
+            }
+            
+            func startFadeAnimation() {
+                // option 값이 nil인 경우(normal 상태), fade 애니메이션을 진행하지 않는다
+                guard let option = option else { return }
+                
+                UIView.animate(
+                    withDuration: 0.6,
+                    delay: 0.3,
+                    animations: {
+                        self.choiceStackView.alpha = 0
+                    },
+                    completion: { [weak self] _ in
+                        guard let self = self else { return }
+                        initializeChoiceView()
+                        self.delegate?.vote(choice: option)
+                    }
+                )
+                
+                func initializeChoiceView() {
+                    choiceStackView.isHidden = true
+                    choiceStackView.center.x = center.x
+                    choiceStackView.alpha = 1
                 }
-            )
-        default:    return
+            }
+    
+        default:
+            return
         }
     }
+}
+
+//MARK: Input
+
+extension HomeTopicCollectionViewCell {
     
-    private func initializeChoiceView() {
-        choiceStackView.isHidden = true
-        choiceStackView.center.x = center.x
-        choiceStackView.alpha = 1
+    func binding(timer: TimerInfo) {
+        topicGroup.timer.binding(data: timer)
     }
     
     func binding(data: HomeTopicItemViewModel) {
@@ -223,10 +265,6 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
         chat.likeCountFrame.binding(data.likeCount)
     }
     
-    func binding(timer: TimerInfo) {
-        topicGroup.timer.binding(data: timer)
-    }
-    
     func select(choice: Choice){
         choiceGroup.completeView.fill(choice: choice)
         toggle(isVoted: true)
@@ -243,14 +281,20 @@ class HomeTopicCollectionViewCell: BaseCollectionViewCell, Binding{
         chat.canUserInteraction = value
     }
     
-    func standardOfCommentBottomSheetNormalState() -> UIView{
-        profileStackView
-    }
-    
     func failVote() {
         choiceStackView.isHidden = false
     }
 }
+
+//MARK: Output
+
+extension HomeTopicCollectionViewCell {
+    func standardOfCommentBottomSheetNormalState() -> UIView{
+        profileStackView
+    }
+}
+
+//MARK: UI
 
 extension HomeTopicCollectionViewCell {
     

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -75,25 +75,15 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         bindTimer()
         bindSelectionSuccess()
         bindImageExpandNotification()
+        bindFailVote()
         
         func bindError() {
             viewModel.errorHandler
                 .receive(on: DispatchQueue.main)
                 .sink{ error in
                     ToastMessage.shared.register(message: error.message)
-                    handleError(code: error.code)
                 }
                 .store(in: &cancellables)
-            
-            func handleError(code: SerivceError) {
-                switch code {
-                case .votedByAuthor, .emptyAuthorization:
-                    //선택지 원위치로 돌리기
-                    currentTopicCell?.moveChoicesOriginalPosition()
-                default:
-                    return
-                }
-            }
         }
         
         func bindReloadTopics(){
@@ -121,7 +111,7 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         }
         
         func bindSelectionSuccess() {
-            viewModel.voteSuccess
+            viewModel.successVote
                 .receive(on: RunLoop.main)
                 .sink{ [weak self] choice in
                     self?.currentTopicCell?.select(choice: choice)
@@ -147,6 +137,16 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
                     if let choice = receive.userInfo?[Choice.identifier] as? Choice {
                         self?.coordinator?.startImagePopUp(choice: choice)
                     }
+                }
+                .store(in: &cancellables)
+        }
+        
+        func bindFailVote() {
+            viewModel.failVote
+                .receive(on: DispatchQueue.main)
+                .sink{ [weak self] in
+                    guard let self = self else { return }
+                    self.currentTopicCell?.failVote()
                 }
                 .store(in: &cancellables)
         }

--- a/Projects/Features/HomeFeature/Sources/ViewModel/DefaultHomeTabViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModel/DefaultHomeTabViewModel.swift
@@ -40,12 +40,13 @@ final class DefaultHomeTabViewModel: BaseViewModel, HomeTabViewModel {
     }
     
     var willMovePage: AnyPublisher<IndexPath, Never>{ $currentIndexPath.filter{ _ in self.topics.count > 0 }.eraseToAnyPublisher() }
-    var voteSuccess: AnyPublisher<Choice, Never> { $selectedOption.compactMap{ $0 }.eraseToAnyPublisher() }
+    var successVote: AnyPublisher<Choice, Never> { $selectedOption.compactMap{ $0 }.eraseToAnyPublisher() }
     
-    let successTopicAction: PassthroughSubject<Topic.Action, Never> = PassthroughSubject()
+    let failVote: PassthroughSubject<Void, Never> = PassthroughSubject()
     let reloadTopics: PassthroughSubject<Void, Never> = PassthroughSubject()
     let timerSubject: PassthroughSubject<TimerInfo, Never> = PassthroughSubject()
     let errorHandler: PassthroughSubject<ErrorContent, Never> = PassthroughSubject()
+    let successTopicAction: PassthroughSubject<Topic.Action, Never> = PassthroughSubject()
     
     private var timer: Timer?
     
@@ -169,8 +170,11 @@ final class DefaultHomeTabViewModel: BaseViewModel, HomeTabViewModel {
                     }()
                     self.selectedOption = self.topics[self.currentIndexPath.row].selectedOption
                 }
-                else if let error = result.error {
-                    self.errorHandler.send(error)
+                else {
+                    if let error = result.error {
+                        self.errorHandler.send(error)
+                    }
+                    self.failVote.send(())
                 }
             }.store(in: &cancellable)
     }


### PR DESCRIPTION
### 투표 실패할 경우, 선택지 다시 보여주기
- 셀 재로드와 선택지 프로퍼티만 변경 중 후자가 훨씬 효율적일 것 같아서 셀에서 투표 실패 UI 처리 메서드를 따로 선언하였습니다. 

### 기타..
- 기존 투표 리셋 기능이 투표 변경하기로 기획 변경되었기 때문에, 투표 재선택을 위해 선택지가 다시 보여주는 로직은 일단 구현 보류하였습니다. 서버 API 나온 이후에 작업 예정입니다. 
- 홈 토픽 셀 내의 코드 스타일을 변경하였습니다. 오버라이드 메서드도 많고, input / output 메서드도 여러 개 있어서 extension으로 섹션 분리하였습니다. 또한 중첩 함수를 적극 활용하였습니다. 


---
close #96