### PR TITLE
[FEATURE] #84: 댓글 바텀시트 기능 추가

### DIFF
--- a/Projects/Core/Sources/UTCTime.swift
+++ b/Projects/Core/Sources/UTCTime.swift
@@ -10,8 +10,23 @@ import Foundation
 
 public struct UTCTime {
     
+    public static let dayUnit = 60*60*24
+    public static let hourUnit = 60*60
+    public static let minuteUnit = 60
+    
     public static var current: Int {
         Int(Date.now.timeIntervalSince1970)
     }
     
+    public static func day(diff: Int) -> Int {
+        diff / UTCTime.dayUnit
+    }
+
+    public static func hour(diff: Int) -> Int {
+        diff % UTCTime.dayUnit / UTCTime.hourUnit
+    }
+
+    public static func minute(diff: Int) -> Int {
+        diff % UTCTime.dayUnit % UTCTime.hourUnit / UTCTime.minuteUnit
+    }
 }

--- a/Projects/Domain/Sources/Entity/Paging.swift
+++ b/Projects/Domain/Sources/Entity/Paging.swift
@@ -22,7 +22,7 @@ public struct Paging{
         self.last = last
     }
     
-    public let page: Int
+    public var page: Int
     public let size: Int
     public let isEmpty: Bool
     public let last: Bool

--- a/Projects/Features/HomeFeature/Interface/HomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Interface/HomeCoordinator.swift
@@ -12,7 +12,7 @@ import Domain
 
 public protocol HomeCoordinator: Coordinator {
     func startTopicBottomSheet()
-    func startCommentBottomSheet(standard: CGFloat, topicId: Int)
+    func startCommentBottomSheet(standard: CGFloat, topicId: Int, choices: [Choice])
     func startImagePopUp(choice: Choice)
     func startWritersBottomSheet(index: Int)
     func startOthersBottomSheet(index: Int)

--- a/Projects/Features/HomeFeature/Interface/ViewModel/CommentBottomSheetViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/CommentBottomSheetViewModel.swift
@@ -21,6 +21,7 @@ public protocol CommentBottomSheetViewModelInput {
     func generateComment(content: String)
     func toggleLikeState(at index: Int)
     func toggleDislikeState(at index: Int)
+    func fetchNextPage()
 }
 
 public protocol CommentBottomSheetViewModelOutput {
@@ -31,6 +32,7 @@ public protocol CommentBottomSheetViewModelOutput {
     var toggleLikeState: PassthroughSubject<Index, Never> { get }
     var toggleDislikeState: PassthroughSubject<Index, Never> { get }
     func isWriterItem(at index: Int) -> Bool
+    func hasNextPage() -> Bool
 }
 
 public protocol WritersCommentBottomSheetViewModelInput {

--- a/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
@@ -43,7 +43,7 @@ public struct CommentListItemViewModel {
     public var isLike: Bool
     public var isHate: Bool
     public var likeCount: Int
-    public var likeCountString: String {
+    public var countOfLike: String {
         String(likeCount)
     }
     public var elapsedTime: String {

--- a/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
@@ -8,40 +8,37 @@
 
 import Foundation
 import Domain
+import Core
 
 public struct CommentListItemViewModel {
-    
-//    public init() {
-//        self.id = 0
-//        self.profileImageUrl = URL(string: "http://ab.")!
-//        self.nickname = "닉네임닉네임"
-//        self.createdAt = "2일전" //comment.date
-//        self.choice = "A. 일이삼사오육칠팔구십일이삼사오육칠팔구십" //comment.choice
-//        self.content = "왜들 그리 다운돼있어? 뭐가 문제야 say something 분위기가 겁나 싸해 요새는 이런 게 유행인가 왜들 그리 재미없어? 아 그건 나도 마찬가지"
-//        self.likeCount = 129
-//        self.isLike = false
-//        self.isHate = false
-//    }
 
     public init(
-        _ comment: Comment
+        _ comment: Comment, _ options: [Choice]
     ) {
         self.id = comment.commentId
         self.profileImageUrl = comment.writer.profileImageURl
         self.nickname = comment.writer.nickname
         self.createdAt = String(describing: comment.createdAt) //TODO: 데이터 가공
-        self.choice = "" //comment.choice //TODO: 데이터 가공
+        self.selectedOption = selectedOption()
         self.content = comment.content
         self.isLike = comment.isLike
         self.isHate = comment.isHate
         self.likeCount = comment.likeCount
+        
+        func selectedOption() -> (Choice.Option?, String) {
+            guard let option = comment.votedOption else {
+                return (nil, "작성자")
+            }
+            return (option, "\(option.content.title).\(options.filter{ $0.option == comment.votedOption }.first!.content.text)")
+        }
     }
     
     public let id: Int
     public let profileImageUrl: URL?
     public let nickname: String
     public let createdAt: String
-    public let choice: String
+    ///option이 nil인 경우, 토픽 작성자를 의미한다
+    public let selectedOption: (option: Choice.Option?, content: String)
     public let content: String
     public var isLike: Bool
     public var isHate: Bool

--- a/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/CommentListItemViewModel.swift
@@ -18,7 +18,7 @@ public struct CommentListItemViewModel {
         self.id = comment.commentId
         self.profileImageUrl = comment.writer.profileImageURl
         self.nickname = comment.writer.nickname
-        self.createdAt = String(describing: comment.createdAt) //TODO: 데이터 가공
+        self.createdAt = comment.createdAt
         self.selectedOption = selectedOption()
         self.content = comment.content
         self.isLike = comment.isLike
@@ -36,7 +36,7 @@ public struct CommentListItemViewModel {
     public let id: Int
     public let profileImageUrl: URL?
     public let nickname: String
-    public let createdAt: String
+    private let createdAt: Int
     ///option이 nil인 경우, 토픽 작성자를 의미한다
     public let selectedOption: (option: Choice.Option?, content: String)
     public let content: String
@@ -45,5 +45,25 @@ public struct CommentListItemViewModel {
     public var likeCount: Int
     public var likeCountString: String {
         String(likeCount)
+    }
+    public var elapsedTime: String {
+
+        if UTCTime.day(diff: diff()) > 0 {
+            return "\(UTCTime.day(diff: diff()))일 전"
+        }
+        else if UTCTime.hour(diff: diff()) > 0 {
+            return "\(UTCTime.hour(diff: diff()))시간 전"
+        }
+        else if UTCTime.minute(diff: diff()) > 0 {
+            return "\(UTCTime.minute(diff: diff()))분 전"
+        }
+        else {
+            return "방금 전"
+        }
+        
+        func diff() -> Int {
+            UTCTime.current - createdAt
+        }
+        
     }
 }

--- a/Projects/Features/HomeFeature/Interface/ViewModel/HomeTopicItemViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/HomeTopicItemViewModel.swift
@@ -45,6 +45,10 @@ extension HomeTopicItemViewModel {
     public var isVoted: Bool {
         selectedOption != nil
     }
+    
+    public var choices: [Choice] {
+        [aOption, bOption]
+    }
 }
 
 private extension Topic.Side {

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
@@ -83,6 +83,13 @@ final class CommentBottomSheetTableViewCell: BaseTableViewCell {
     private let dislikeContent: LikeContentView = LikeContentView(state: .dislike)
     private var cancellable: Set<AnyCancellable> = []
     
+    override func prepareForReuse() {
+        choiceLabel.textColor = Color.white
+        choiceLabel.text = ""
+        state(isLike: false, count: "0")
+        state(isDislike: false)
+    }
+    
     override func hierarchy() {
         topStackView.addArrangedSubviews([nicknameLabel, dotView, dateLabel])
         likeStackView.addArrangedSubviews([likeContent, dislikeContent])
@@ -144,7 +151,8 @@ final class CommentBottomSheetTableViewCell: BaseTableViewCell {
     func fill(_ comment: CommentListItemViewModel) {
         nicknameLabel.text = comment.nickname
         dateLabel.text = comment.createdAt
-        choiceLabel.text = comment.choice
+        choiceLabel.textColor = (comment.selectedOption.option?.content.color ?? Color.subNavy).withAlphaComponent(0.6)
+        choiceLabel.text = comment.selectedOption.content
         contentLabel.text = comment.content
         state(isLike: comment.isLike, count: comment.likeCountString)
         state(isDislike: comment.isHate)

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
@@ -154,7 +154,7 @@ final class CommentBottomSheetTableViewCell: BaseTableViewCell {
         choiceLabel.textColor = (comment.selectedOption.option?.content.color ?? Color.subNavy).withAlphaComponent(0.6)
         choiceLabel.text = comment.selectedOption.content
         contentLabel.text = comment.content
-        state(isLike: comment.isLike, count: comment.likeCountString)
+        state(isLike: comment.isLike, count: comment.countOfLike)
         state(isDislike: comment.isHate)
     }
     

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/CommentBottomSheetTableViewCell.swift
@@ -150,7 +150,7 @@ final class CommentBottomSheetTableViewCell: BaseTableViewCell {
     
     func fill(_ comment: CommentListItemViewModel) {
         nicknameLabel.text = comment.nickname
-        dateLabel.text = comment.createdAt
+        dateLabel.text = comment.elapsedTime
         choiceLabel.textColor = (comment.selectedOption.option?.content.color ?? Color.subNavy).withAlphaComponent(0.6)
         choiceLabel.text = comment.selectedOption.content
         contentLabel.text = comment.content

--- a/Projects/Features/HomeFeature/Sources/Cell/HomeTab/LoadingTableViewCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Cell/HomeTab/LoadingTableViewCell.swift
@@ -1,0 +1,32 @@
+//
+//  LoadingTableViewCell.swift
+//  HomeFeature
+//
+//  Created by 박소윤 on 2024/01/03.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import ABKit
+
+final class LoadingTableViewCell: BaseTableViewCell {
+    
+    private let loadingView = UIActivityIndicatorView()
+    
+    override func hierarchy() {
+        super.hierarchy()
+        baseView.addSubview(loadingView)
+    }
+    
+    override func layout() {
+        super.layout()
+        loadingView.snp.makeConstraints{
+            $0.centerY.centerX.equalToSuperview()
+        }
+    }
+    
+    func startLoading(){
+        loadingView.startAnimating()
+    }
+}

--- a/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
@@ -67,7 +67,7 @@ public class DefaultHomeCoordinator: HomeCoordinator {
         navigationController.present(TopicBottomSheetViewController(viewModel: homeViewModel), animated: true)
     }
     
-    public func startCommentBottomSheet(standard: CGFloat, topicId: Int) {
+    public func startCommentBottomSheet(standard: CGFloat, topicId: Int, choices: [Choice]) {
         
         commentBottomSheet = CommentBottomSheetViewController(standard: standard, viewModel: viewModel())
         commentBottomSheet?.coordinator = self
@@ -79,6 +79,7 @@ public class DefaultHomeCoordinator: HomeCoordinator {
         func viewModel() -> CommentBottomSheetViewModel {
             commentBottomSheetViewModel = DefaultCommentBottomSheetViewModel(
                 topicId: topicId,
+                choices: choices,
                 generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
                 fetchCommentsUseCase: DefaultFetchCommentsUseCase(repository: commentRepository),
                 patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),

--- a/Projects/Features/HomeFeature/Sources/ViewController/BottomSheet/CommentBottomSheetViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/BottomSheet/CommentBottomSheetViewController.swift
@@ -190,7 +190,7 @@ final class CommentBottomSheetViewController: UIViewController {
             .sink{ [weak self] index in
                 guard let self = self else { return }
                 let cell = self.tableView.cellForRow(at: .init(row: index), cellType: CommentBottomSheetTableViewCell.self)
-                cell?.state(isLike: self.viewModel.comments[index].isLike, count: self.viewModel.comments[index].likeCountString)
+                cell?.state(isLike: self.viewModel.comments[index].isLike, count: self.viewModel.comments[index].countOfLike)
             }
             .store(in: &cancellable)
         

--- a/Projects/Features/HomeFeature/Sources/ViewController/BottomSheet/CommentBottomSheetViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/BottomSheet/CommentBottomSheetViewController.swift
@@ -41,6 +41,7 @@ final class CommentBottomSheetViewController: UIViewController {
     
     private let normalStateY: CGFloat
     private let expandStateY: CGFloat = (Device.safeAreaInsets?.top ?? 0) + 10
+    private let tableViewBottomInset: CGFloat = 58
     private let commentInputView: CommentInputView = CommentInputView()
     private lazy var normalHeight: CGFloat = Device.height - normalStateY
     private lazy var expandHeight: CGFloat = Device.height - expandStateY
@@ -63,10 +64,11 @@ final class CommentBottomSheetViewController: UIViewController {
         return view
     }()
     private let headerView: CommentHeaderView = CommentHeaderView()
-    private let tableView: UITableView = {
+    private lazy var tableView: UITableView = {
         let tableView: UITableView = UITableView()
         tableView.separatorStyle = .none
         tableView.registers(cellTypes: [CommentBottomSheetTableViewCell.self])
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: tableViewBottomInset, right: 0)
         return tableView
     }()
     
@@ -144,6 +146,7 @@ final class CommentBottomSheetViewController: UIViewController {
                         withDuration: 0.25
                         , animations: { [weak self] in
                             self?.commentInputView.transform = CGAffineTransform(translationX: 0, y: -keyboardRectangle.height)
+                            self?.tableView.contentInset.bottom += keyboardRectangle.height
                         }
                     )
                 }
@@ -153,7 +156,9 @@ final class CommentBottomSheetViewController: UIViewController {
         NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
             .receive(on: DispatchQueue.main)
             .sink{ [weak self] _ in
-                self?.commentInputView.transform = .identity
+                guard let self = self else { return }
+                self.commentInputView.transform = .identity
+                self.tableView.contentInset.bottom = self.tableViewBottomInset
             }
             .store(in: &cancellable)
         

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -195,7 +195,8 @@ extension HomeTabViewController: ChatBottomSheetDelegate, TopicBottomSheetDelega
             coordinator?
                 .startCommentBottomSheet(
                     standard: standardOfCommentBottomSheet(),
-                    topicId: viewModel.currentTopic.id
+                    topicId: viewModel.currentTopic.id,
+                    choices: viewModel.currentTopic.choices
                 )
         default:
             return

--- a/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
@@ -58,6 +58,11 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
     public func isWriterItem(at index: Int) -> Bool {
         index % 2 == 0 ? true : false //comments[index].userId == userId
     }
+    
+    public func hasNextPage() -> Bool {
+        guard let pageInfo = pageInfo else { return false }
+        return !pageInfo.last
+    }
 }
 
 //MARK: - INPUT
@@ -69,7 +74,6 @@ extension DefaultCommentBottomSheetViewModel {
             .sink{ [weak self] result in
                 guard let self = self else { return }
                 if result.isSuccess, let (pageInfo, data) = result.data {
-                    //TODO: 페이징 코드 추가
                     self.pageInfo = pageInfo
                     self.comments.append(contentsOf: data.map{ .init($0) })
                     self.reloadData?()
@@ -79,6 +83,15 @@ extension DefaultCommentBottomSheetViewModel {
                 }
             }
             .store(in: &cancellable)
+    }
+    
+    public func fetchNextPage() {
+        updatePage()
+        fetchComments()
+        
+        func updatePage() {
+            pageInfo?.page += 1
+        }
     }
     
     public func toggleLikeState(at index: Int) {

--- a/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
@@ -17,6 +17,7 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
 
     private var pageInfo: Paging?
     private let topicId: Int
+    private let choices: [Choice]
     private let generateCommentUseCase: any GenerateCommentUseCase
     private let fetchCommentsUseCase: any FetchCommentsUseCase
     private let patchCommentUseCase: any PatchCommentUseCase
@@ -26,6 +27,7 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
     
     public init(
         topicId: Int,
+        choices: [Choice],
         generateCommentUseCase: any GenerateCommentUseCase,
         fetchCommentsUseCase: any FetchCommentsUseCase,
         patchCommentUseCase: any PatchCommentUseCase,
@@ -34,6 +36,7 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
         deleteCommentUseCase: any DeleteCommentUseCase
     ) {
         self.topicId = topicId
+        self.choices = choices
         self.generateCommentUseCase = generateCommentUseCase
         self.fetchCommentsUseCase = fetchCommentsUseCase
         self.patchCommentUseCase = patchCommentUseCase
@@ -75,7 +78,7 @@ extension DefaultCommentBottomSheetViewModel {
                 guard let self = self else { return }
                 if result.isSuccess, let (pageInfo, data) = result.data {
                     self.pageInfo = pageInfo
-                    self.comments.append(contentsOf: data.map{ .init($0) })
+                    self.comments.append(contentsOf: data.map{ .init($0, self.choices) })
                     self.reloadData?()
                 }
                 else if let error = result.error {
@@ -140,7 +143,7 @@ extension DefaultCommentBottomSheetViewModel {
                 guard let self = self else { return }
                 
                 if result.isSuccess, let data = result.data {
-                    self.comments.insert(.init(data), at: 0)
+                    self.comments.insert(.init(data, self.choices), at: 0)
                     self.generateItem.send(())
                 }
                 else if let error = result.error {
@@ -159,7 +162,7 @@ extension DefaultCommentBottomSheetViewModel {
                 guard let self = self else { return }
                 
                 if result.isSuccess, let data = result.data {
-                    self.comments[index] = .init(data)
+                    self.comments[index] = .init(data, self.choices)
                     self.modifyItem.send(index)
                 }
                 else if let error = result.error {


### PR DESCRIPTION
### 댓글 입력창으로 인해 일부 댓글들 가려지는 문제 해결
- 레이아웃을 건드리는 것은 너무 골치아픈 것 같아서 table view의 content inset으로 해결하였습니다. 

### 댓글 바텀시트 페이징 기능 추가
- 페이징에서 필요한 로딩 UI는 일단 애플에서 기본으로 제공하는 것으로 임시 구현했습니다. 
- 추후 디자인이 나온다면 수정하도록 하겠습니다. 

### 댓글 작성자가 투표한 선택지 보여주기

### 댓글 작성 시간 포맷 바인딩
- UTCTime 구조체에 날짜/시간/분/초 연산을 추가했는데, 추후 토픽 타이머에 구현한 시간 연산도 이를 활용하는 것으로 리팩토링 하겠습니다. 

---
close #84