### PR TITLE
[FEATURE] #116: 토픽 생성 이미지 업로드 API 연결

### DIFF
--- a/Projects/Data/Sources/DTO/NetworkErrorResponseDTO.swift
+++ b/Projects/Data/Sources/DTO/NetworkErrorResponseDTO.swift
@@ -32,7 +32,7 @@ extension NetworkErrorResponeDTO: Domainable {
 
     public func toDomain() -> ErrorContent {
         .init(
-            code: NetworkSerivceError(rawValue: code)!,
+            code: NetworkServiceError(rawValue: code)!,
             message: content.message
         )
     }

--- a/Projects/Data/Sources/DTO/NetworkErrorResponseDTO.swift
+++ b/Projects/Data/Sources/DTO/NetworkErrorResponseDTO.swift
@@ -32,7 +32,7 @@ extension NetworkErrorResponeDTO: Domainable {
 
     public func toDomain() -> ErrorContent {
         .init(
-            code: SerivceError(rawValue: code)!,
+            code: NetworkSerivceError(rawValue: code)!,
             message: content.message
         )
     }

--- a/Projects/Data/Sources/DTO/PresignedImage/PresignedImageRequestDTO.swift
+++ b/Projects/Data/Sources/DTO/PresignedImage/PresignedImageRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PresignedImageRequestDTO.swift
+//  Data
+//
+//  Created by 박소윤 on 2024/01/04.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+
+struct PresignedImageRequestDTO: Encodable {
+    let fileName: String
+}

--- a/Projects/Data/Sources/DTO/PresignedImage/PresignedImageResponseDTO.swift
+++ b/Projects/Data/Sources/DTO/PresignedImage/PresignedImageResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PresignedImageResponseDTO.swift
+//  Data
+//
+//  Created by 박소윤 on 2024/01/04.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+
+struct PresignedImageResponseDTO: Decodable {
+    let presignedUrl: String
+}

--- a/Projects/Data/Sources/DTO/Topic/TopicGenerateRequestDTO.swift
+++ b/Projects/Data/Sources/DTO/Topic/TopicGenerateRequestDTO.swift
@@ -24,7 +24,7 @@ struct TopicGenerateRequestDTO: Encodable {
         
         struct ContentRequestDTO: Encodable {
             let type: String
-            let imageUrl: String
+            let imageUrl: String?
             let text: String
         }
     }

--- a/Projects/Data/Sources/Network/HTTPMethod.swift
+++ b/Projects/Data/Sources/Network/HTTPMethod.swift
@@ -13,4 +13,5 @@ public enum HTTPMethod: String {
     case post = "POST"
     case delete = "DELETE"
     case patch = "PATCH"
+    case put = "PUT"
 }

--- a/Projects/Data/Sources/Network/NetworkServiceResultPublisher.swift
+++ b/Projects/Data/Sources/Network/NetworkServiceResultPublisher.swift
@@ -9,4 +9,5 @@
 import Foundation
 import Combine
 
+public typealias NetworkServiceResult<DTO> = (isSuccess: Bool, data: DTO, error: NetworkErrorResponeDTO?)
 public typealias NetworkServiceResultPublisher<DTO> = AnyPublisher<(isSuccess: Bool, data: DTO, error: NetworkErrorResponeDTO?), Never>

--- a/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
@@ -1,0 +1,84 @@
+//
+//  DefaultPresignedImageRepository.swift
+//  Data
+//
+//  Created by 박소윤 on 2024/01/04.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import Domain
+
+protocol PresignedImageRepository: Repository {
+    func upload(bucket: ImageBucket, request: UIImage) async throws -> String?
+}
+
+enum ImageBucket {
+    
+    case profile
+    case topic
+    
+    var method: HTTPMethod {
+        switch self {
+        case .profile, .topic:      return .post
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .profile:      return "profile"
+        case .topic:        return "topic"
+        }
+    }
+}
+
+final class DefaultPresignedImageRepository: PresignedImageRepository {
+
+    private let networkService: NetworkService = NetworkService.shared
+    
+    public init() { }
+    
+    func upload(bucket: ImageBucket, request image: UIImage) async throws -> String? {
+
+        let response = await requestPresignedUrl()
+        
+        guard let url = response.data?.presignedUrl else {
+            return nil
+        }
+        
+        let urlComponents = URLComponents(string: String(url.split(separator: "?").first!))
+        
+        guard let urlRequest = urlComponents?.toURLRequest(method: .put, httpBody: image.jpegData(compressionQuality: 1), contentType: "image/jpeg") else {
+            fatalError("url parsing error")
+        }
+        
+        if await networkService.dataTask(request: urlRequest, type: EmptyData.self).isSuccess {
+            return url
+        } else {
+            throw ABError.imageUpload
+        }
+        
+        func requestPresignedUrl() async -> NetworkServiceResult<PresignedImageResponseDTO?> {
+
+            var urlComponents = networkService.baseUrlComponents
+            urlComponents?.path = path("images") + path(bucket.path)
+
+            guard let requestBody = try? JSONEncoder().encode(makeDTO()) else {
+                fatalError("json parsing error")
+            }
+            guard let urlRequest = urlComponents?.toURLRequest(method: .post, httpBody: requestBody) else {
+                fatalError("url parsing error")
+            }
+
+            return await networkService.dataTask(request: urlRequest, type: PresignedImageResponseDTO.self)
+
+            func makeDTO() -> PresignedImageRequestDTO {
+                let id = UUID().uuidString
+                let fileKey = "\(bucket.path)/\(id).jpeg"
+                return .init(fileName: fileKey)
+            }
+        }
+    }
+    
+}

--- a/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
@@ -44,7 +44,7 @@ final class DefaultPresignedImageRepository: PresignedImageRepository {
         let response = await requestPresignedUrl()
         
         guard let url = response.data?.presignedUrl else {
-            throw ABError.imageUpload
+            throw NetworkServiceError.IMAGE_UPLOAD_FAIL
         }
         
         let urlComponents = URLComponents(string: String(url.split(separator: "?").first!))
@@ -56,7 +56,7 @@ final class DefaultPresignedImageRepository: PresignedImageRepository {
         if await networkService.dataTask(request: urlRequest, type: EmptyData.self).isSuccess {
             return url
         } else {
-            throw ABError.imageUpload
+            throw NetworkServiceError.IMAGE_UPLOAD_FAIL
         }
         
         func requestPresignedUrl() async -> NetworkServiceResult<PresignedImageResponseDTO?> {

--- a/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultPresignedImageRepository.swift
@@ -11,7 +11,7 @@ import UIKit
 import Domain
 
 protocol PresignedImageRepository: Repository {
-    func upload(bucket: ImageBucket, request: UIImage) async throws -> String?
+    func upload(bucket: ImageBucket, request: UIImage) async throws -> String
 }
 
 enum ImageBucket {
@@ -39,12 +39,12 @@ final class DefaultPresignedImageRepository: PresignedImageRepository {
     
     public init() { }
     
-    func upload(bucket: ImageBucket, request image: UIImage) async throws -> String? {
+    func upload(bucket: ImageBucket, request image: UIImage) async throws -> String {
 
         let response = await requestPresignedUrl()
         
         guard let url = response.data?.presignedUrl else {
-            return nil
+            throw ABError.imageUpload
         }
         
         let urlComponents = URLComponents(string: String(url.split(separator: "?").first!))

--- a/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
@@ -32,7 +32,7 @@ public final class DefaultTopicRepository: TopicRepository {
             }
             return dataTask(request: urlRequest, responseType: TopicResponseDTO.self)
         }
-        catch ABError.imageUpload {
+        catch NetworkServiceError.IMAGE_UPLOAD_FAIL {
             print("image upload 실패")
             return Just((false, nil, nil)).eraseToAnyPublisher()
         }

--- a/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
@@ -9,48 +9,67 @@
 import Foundation
 import Domain
 import Core
+import Combine
 
 public final class DefaultTopicRepository: TopicRepository {
     
     private let networkService: NetworkService = NetworkService.shared
     private let basePath = "/topics"
+    private let presignedImageRepository: PresignedImageRepository = DefaultPresignedImageRepository()
     
     public init() { }
     
-    public func generateTopic(request: GenerateTopicUseCaseRequestValue) -> NetworkResultPublisher<Topic?> {
+    public func generateTopic(request: GenerateTopicUseCaseRequestValue) async -> NetworkResultPublisher<Topic?> {
         
         var urlComponents = networkService.baseUrlComponents
         urlComponents?.path = basePath
         
-        guard let requestBody = try? JSONEncoder().encode(makeDTO()),
-              let urlRequest = urlComponents?.toURLRequest(method: .post, httpBody: requestBody) else {
-            fatalError("json encoding or url parsing error")
+        do {
+            let dto = try await makeDTO()
+            guard let requestBody = try? JSONEncoder().encode(dto),
+                  let urlRequest = urlComponents?.toURLRequest(method: .post, httpBody: requestBody) else {
+                fatalError("json encoding or url parsing error")
+            }
+            return dataTask(request: urlRequest, responseType: TopicResponseDTO.self)
+        }
+        catch ABError.imageUpload {
+            print("image upload 실패")
+            return Just((false, nil, nil)).eraseToAnyPublisher()
+        }
+        catch {
+            fatalError()
         }
         
-        return dataTask(request: urlRequest, responseType: TopicResponseDTO.self)
-        
-        func makeDTO() -> TopicGenerateRequestDTO {
+        func makeDTO() async throws -> TopicGenerateRequestDTO {
             .init(
                 side: request.side.toDTO(),
                 keywordName: request.keyword,
                 title: request.title,
-                choices: makeChoicesDTO(),
+                choices: try await makeChoicesDTO(),
                 deadline: request.deadline
             )
         }
         
-        func makeChoicesDTO() -> [TopicGenerateRequestDTO.ChoiceRequestDTO] {
-            request.choices
-                .map{ choice in
+        func makeChoicesDTO() async throws -> [TopicGenerateRequestDTO.ChoiceRequestDTO] {
+            let images = request.choices.compactMap{ $0.image }
+            var url = [String?](repeating: nil, count: request.choices.count)
+            if !images.isEmpty {
+                for (i,image) in images.enumerated() {
+                    url[i] = try await presignedImageRepository.upload(bucket: .topic, request: image)
+                }
+            }
+            
+            return request.choices.enumerated()
+                .map{ i, choice in
                         .init(
                             choiceOption: choice.option.toDTO(),
                             choiceContentRequest: .init(
                                 type: "IMAGE_TEXT",
-                                imageUrl: String(describing: choice.image), //TODO: 이미지 전송 코드 적용
+                                imageUrl: url[i],
                                 text: choice.text
+                            )
                         )
-                    )
-            }
+                }
         }
     }
     

--- a/Projects/Data/Sources/Repository/Repository.swift
+++ b/Projects/Data/Sources/Repository/Repository.swift
@@ -16,7 +16,7 @@ public extension Repository {
     }
     
     func dataTask<DTO: Domainable>(request: URLRequest, responseType: DTO.Type = EmptyData.self) -> NetworkResultPublisher<DTO.Output?> {
-        return NetworkService.shared.dataTask(request: request, type: DTO.self)
+        return NetworkService.shared.dataTaskPublisher(request: request, type: DTO.self)
             .map{ (isSuccess, dto, error) in
                 return (isSuccess, dto?.toDomain(), error?.toDomain())
             }
@@ -24,7 +24,7 @@ public extension Repository {
     }
     
     func arrayDataTask<DTO: Domainable>(request: URLRequest, elementType: DTO.Type) -> NetworkResultPublisher<[DTO.Output]> {
-        return NetworkService.shared.dataTask(request: request, type: [DTO].self)
+        return NetworkService.shared.dataTaskPublisher(request: request, type: [DTO].self)
             .map{ (isSuccess, dto, error) in
                 return (isSuccess, dto?.map{ $0.toDomain() } ?? [], error?.toDomain())
             }

--- a/Projects/Domain/Sources/ABError.swift
+++ b/Projects/Domain/Sources/ABError.swift
@@ -1,0 +1,13 @@
+//
+//  ABError.swift
+//  Domain
+//
+//  Created by 박소윤 on 2024/01/05.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+
+public enum ABError: Error {
+    case imageUpload
+}

--- a/Projects/Domain/Sources/ABError.swift
+++ b/Projects/Domain/Sources/ABError.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public enum ABError: Error {
-    case imageUpload
+    
 }

--- a/Projects/Domain/Sources/Entity/ErrorContent.swift
+++ b/Projects/Domain/Sources/Entity/ErrorContent.swift
@@ -11,13 +11,13 @@ import Foundation
 public struct ErrorContent {
     
     public init(
-        code: SerivceError,
+        code: NetworkSerivceError,
         message: String
     ) {
         self.code = code
         self.message = message
     }
     
-    public let code: SerivceError
+    public let code: NetworkSerivceError
     public let message: String
 }

--- a/Projects/Domain/Sources/Entity/ErrorContent.swift
+++ b/Projects/Domain/Sources/Entity/ErrorContent.swift
@@ -11,13 +11,13 @@ import Foundation
 public struct ErrorContent {
     
     public init(
-        code: NetworkSerivceError,
+        code: NetworkServiceError,
         message: String
     ) {
         self.code = code
         self.message = message
     }
     
-    public let code: NetworkSerivceError
+    public let code: NetworkServiceError
     public let message: String
 }

--- a/Projects/Domain/Sources/NetworkSerivceError.swift
+++ b/Projects/Domain/Sources/NetworkSerivceError.swift
@@ -9,11 +9,27 @@
 import Foundation
 
 public enum NetworkSerivceError: String {
+    
     case emptyAuthorization = "EMPTY_AUTHORIZATION"
-    case votedByAuthor = "VOTED_BY_AUTHOR"
-    case futureTimeRequest = "FUTURE_TIME_REQUEST"
-    case memberNotVote = "MEMBER_NOT_VOTE"
     case invalidField = "INVALID_FIELD"
-    case topicNotFound = "TOPIC_NOT_FOUND"
-    case duplicateTopicReport = "DUPLICATE_TOPIC_REPORT"
+    
+    //MARK: Topic
+    case TOPIC_NOT_FOUND
+    case DUPLICATE_TOPIC_REPORT
+    case ILLEGAL_TOPIC_STATUS_CHANGE
+    case VOTED_BY_AUTHOR
+    case FUTURE_TIME_REQUEST
+    case MEMBER_NOT_VOTE
+    case DUPLICATE_VOTE
+    
+    //MARK: Auth
+    case ILLEGAL_JOIN_STATUS
+    
+    //MARK: Comment
+    case INVALID_LENGTH_OF_FIELD
+    case UNABLE_TO_VIEW_COMMENTS
+    case ILLEGAL_COMMENT_STATUS_CHANGE
+    
+    //MARK: Image Presigned
+    case ILLEGAL_FILE_EXTENSION
 }

--- a/Projects/Domain/Sources/NetworkSerivceError.swift
+++ b/Projects/Domain/Sources/NetworkSerivceError.swift
@@ -1,5 +1,5 @@
 //
-//  ServiceError.swift
+//  NetworkSerivceError.swift
 //  Domain
 //
 //  Created by 박소윤 on 2023/12/11.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum SerivceError: String {
+public enum NetworkSerivceError: String {
     case emptyAuthorization = "EMPTY_AUTHORIZATION"
     case votedByAuthor = "VOTED_BY_AUTHOR"
     case futureTimeRequest = "FUTURE_TIME_REQUEST"

--- a/Projects/Domain/Sources/NetworkServiceError.swift
+++ b/Projects/Domain/Sources/NetworkServiceError.swift
@@ -32,4 +32,7 @@ public enum NetworkServiceError: String, Error {
     
     //MARK: Image Presigned
     case ILLEGAL_FILE_EXTENSION
+    
+    //MARK: Custom
+    case IMAGE_UPLOAD_FAIL
 }

--- a/Projects/Domain/Sources/NetworkServiceError.swift
+++ b/Projects/Domain/Sources/NetworkServiceError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum NetworkSerivceError: String {
+public enum NetworkServiceError: String, Error {
     
     case emptyAuthorization = "EMPTY_AUTHORIZATION"
     case invalidField = "INVALID_FIELD"

--- a/Projects/Domain/Sources/RepositoryInterface/TopicRepository.swift
+++ b/Projects/Domain/Sources/RepositoryInterface/TopicRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 import Core
 
 public protocol TopicRepository: Repository{
-    func generateTopic(request: GenerateTopicUseCaseRequestValue) -> NetworkResultPublisher<Topic?>
+    func generateTopic(request: GenerateTopicUseCaseRequestValue) async -> NetworkResultPublisher<Topic?>
     func fetchTopic(keywordId: Int?, paging: Paging?, sort: String?) -> NetworkResultPublisher<(Paging, [Topic])?>
     func report(topicId: Int) -> NetworkResultPublisher<Any?>
     func vote(topicId: Int, request: GenerateVoteUseCaseRequestValue) -> NetworkResultPublisher<Any?>

--- a/Projects/Domain/Sources/UseCase/Topic/GenerateTopicUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Topic/GenerateTopicUseCase.swift
@@ -11,7 +11,7 @@ import Core
 import UIKit
 
 public protocol GenerateTopicUseCase: UseCase {
-    func execute(request: GenerateTopicUseCaseRequestValue) -> NetworkResultPublisher<Topic?>
+    func execute(request: GenerateTopicUseCaseRequestValue) async -> NetworkResultPublisher<Topic?>
 }
 
 public final class DefaultGenerateTopicUseCase: GenerateTopicUseCase {
@@ -22,8 +22,8 @@ public final class DefaultGenerateTopicUseCase: GenerateTopicUseCase {
         self.repository = repository
     }
     
-    public func execute(request: GenerateTopicUseCaseRequestValue) -> NetworkResultPublisher<Topic?> {
-        repository.generateTopic(request: request)
+    public func execute(request: GenerateTopicUseCaseRequestValue) async -> NetworkResultPublisher<Topic?> {
+        await repository.generateTopic(request: request)
     }
 }
 

--- a/Projects/Features/RootFeature/Sources/TabBar/TabBarController.swift
+++ b/Projects/Features/RootFeature/Sources/TabBar/TabBarController.swift
@@ -202,7 +202,7 @@ extension TabBarController {
             }
         }
         
-        private func initialize() {
+        override func initialize() {
             tag = item.rawValue
             iconImageView.image = item.defaultIcon
             titleLabel.text = item.title

--- a/Projects/Features/TopicFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
+++ b/Projects/Features/TopicFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
@@ -130,18 +130,20 @@ final class DefaultTopicGenerateViewModel: BaseViewModel, TopicGenerateViewModel
     }
     
     func register(_ request: GenerateTopicUseCaseRequestValue) {
-        topicGenerateUseCase.execute(request: request)
-            .sink{ [weak self] result in
-                if result.isSuccess {
-                    print("success")
-                }
-                else {
-                    if let error = result.error {
-                        self?.errorHandler.send(error)
+        Task {
+            await topicGenerateUseCase.execute(request: request)
+                .sink{ [weak self] result in
+                    if result.isSuccess {
+                        print("success")
+                    }
+                    else {
+                        if let error = result.error {
+                            self?.errorHandler.send(error)
+                        }
                     }
                 }
-            }
-            .store(in: &cancellable)
+                .store(in: &cancellable)
+        }
     }
     
     


### PR DESCRIPTION
### NetworkServiceError 에러 타입 지정
+ 기존에 서버에서 받은 도메인 에러를 타입으로 관리하는 용도로만 사용해 Error 타입 지정을 안했었습니다. 
+ 레포지토리 메서드 내에서 직접 에러를 던지기 위해 에러 타입으로 지정하였습니다. 

### Presigned Image 레포지토리 구현
- 토픽 생성의 경우 2개의 이미지 업로드가 필요한데, 반복문 내에서 비동기로 업로드 API를 요청할 수 있도록 코드를 작성하였습니다. 
- 이미지 업로드가 접근 오류(?)로 실패가 발생하는데, 이 부분은 담주 회의에 서버랑 이야기해볼 예정입니다. 

---
close #116