### PR TITLE
[TEST] #86: 댓글 바텀시트 View Model 테스트 코드 작성

### DIFF
--- a/Projects/Domain/Sources/Entity/Comment.swift
+++ b/Projects/Domain/Sources/Entity/Comment.swift
@@ -25,7 +25,7 @@ public struct Comment {
         commentId: Int,
         topicId: Int,
         writer: Comment.WriterEntity,
-        votedOption: Choice.Option? = nil,
+        votedOption: Choice.Option?,
         content: String,
         likeCount: Int,
         hateCount: Int,

--- a/Projects/Features/CommentFeature/Interface/CommentBottomSheetViewModel.swift
+++ b/Projects/Features/CommentFeature/Interface/CommentBottomSheetViewModel.swift
@@ -27,6 +27,7 @@ public protocol CommentBottomSheetViewModelInput {
 public protocol CommentBottomSheetViewModelOutput {
     var comments: [CommentListItemViewModel] { get }
     var commentsCountTitle: String { get }
+    var currentPage: Int { get }
     var reloadData: (() -> Void)? { get set }
     var generateItem: PassthroughSubject<Void, Never> { get }
     var toggleLikeState: PassthroughSubject<Index, Never> { get }

--- a/Projects/Features/CommentFeature/Interface/CommentListItemViewModel.swift
+++ b/Projects/Features/CommentFeature/Interface/CommentListItemViewModel.swift
@@ -16,8 +16,7 @@ public struct CommentListItemViewModel {
         _ comment: Comment, _ options: [Choice]
     ) {
         self.id = comment.commentId
-        self.profileImageUrl = comment.writer.profileImageURl
-        self.nickname = comment.writer.nickname
+        self.writer = .init(id: comment.writer.id, nickname: comment.writer.nickname, profileImageUrl: comment.writer.profileImageURl)
         self.createdAt = comment.createdAt
         self.selectedOption = selectedOption()
         self.content = comment.content
@@ -65,5 +64,13 @@ public struct CommentListItemViewModel {
             UTCTime.current - createdAt
         }
         
+    }
+}
+
+extension CommentListItemViewModel {
+    public struct WriterItemViewModel{
+        public let id: Int
+        public let nickname: String
+        public let profileImageUrl: URL?
     }
 }

--- a/Projects/Features/CommentFeature/Interface/CommentListItemViewModel.swift
+++ b/Projects/Features/CommentFeature/Interface/CommentListItemViewModel.swift
@@ -33,8 +33,7 @@ public struct CommentListItemViewModel {
     }
     
     public let id: Int
-    public let profileImageUrl: URL?
-    public let nickname: String
+    public let writer: WriterItemViewModel
     private let createdAt: Int
     ///option이 nil인 경우, 토픽 작성자를 의미한다
     public let selectedOption: (option: Choice.Option?, content: String)

--- a/Projects/Features/CommentFeature/Sources/Cell/CommentBottomSheetTableViewCell.swift
+++ b/Projects/Features/CommentFeature/Sources/Cell/CommentBottomSheetTableViewCell.swift
@@ -149,7 +149,7 @@ final class CommentContentTableViewCell: BaseTableViewCell {
     }
     
     func fill(_ comment: CommentListItemViewModel) {
-        nicknameLabel.text = comment.nickname
+        nicknameLabel.text = comment.writer.nickname
         dateLabel.text = comment.elapsedTime
         choiceLabel.textColor = (comment.selectedOption.option?.content.color ?? Color.subNavy).withAlphaComponent(0.6)
         choiceLabel.text = comment.selectedOption.content

--- a/Projects/Features/CommentFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
+++ b/Projects/Features/CommentFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
@@ -48,6 +48,7 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
     
     //MARK: - OUTPUT
     public var reloadData: (() -> Void)?
+    public var currentPage: Int { pageInfo?.page ?? 0 }
     public var commentsCountTitle: String { ABFormat.count(comments.count) + " 개" }
     public var comments: [CommentListItemViewModel] = []
     public let toggleLikeState: PassthroughSubject<Index, Never> = PassthroughSubject()

--- a/Projects/Features/CommentFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
+++ b/Projects/Features/CommentFeature/Sources/ViewModel/DefaultCommentBottomSheetViewModel.swift
@@ -59,7 +59,7 @@ public final class DefaultCommentBottomSheetViewModel: BaseViewModel, CommentBot
     public let errorHandler: PassthroughSubject<ErrorContent, Never> = PassthroughSubject()
     
     public func isWriterItem(at index: Int) -> Bool {
-        index % 2 == 0 ? true : false //comments[index].userId == userId
+        comments[index].writer.id == UserManager.shared.memberId
     }
     
     public func hasNextPage() -> Bool {

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -48,7 +48,7 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         func setDefaultComments() {
             fetchCommentsUseCase.comments = [
                 .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
-                .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current)
+                .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 1, hateCount: 1, isLike: true, isHate: true, createdAt: UTCTime.current)
             ]
         }
     }
@@ -112,13 +112,53 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
     }
     
     func test_when_댓글_좋아요_성공_then_댓글_데이터_변화_확인() {
+        
+        let expectation = expectation(description: "댓글 좋아요 성공한 경우, publisher가 방출되며 댓글 데이터가 정상적으로 변경되었는지 확인")
+        
         //given
+        fetchCommentsUseCase.mockType = .success
         patchLikeUseCase.mockType = .success
         guard let sut = commentBottomSheetViewModel else { return }
+        sut.fetchComments()
+        sut.toggleLikeState
+            .sink{ index in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertTrue(sut.comments[index].isLike)
+                XCTAssertEqual(sut.comments[index].likeCount, 1)
+            }
+            .store(in: &cancellable)
+        
+        //when
+        sut.toggleLikeState(at: 0)
+        
+        waitForExpectations(timeout: 10)
     }
     
     func test_when_댓글_좋아요_취소_성공_then_댓글_데이터_변화_확인() {
         
+        let expectation = expectation(description: "댓글 좋아요 취소 성공한 경우, publisher가 방출되며 댓글 데이터가 정상적으로 변경되었는지 확인")
+        
+        //given
+        fetchCommentsUseCase.mockType = .success
+        patchLikeUseCase.mockType = .success
+        guard let sut = commentBottomSheetViewModel else { return }
+        sut.fetchComments()
+        sut.toggleLikeState
+            .sink{ index in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertTrue(!sut.comments[index].isLike)
+                XCTAssertEqual(sut.comments[index].likeCount, 0)
+            }
+            .store(in: &cancellable)
+        
+        //when
+        sut.toggleLikeState(at: 1)
+        
+        waitForExpectations(timeout: 10)
     }
     
     func test_when_댓글_싫어요_성공_then_댓글_데이터_변화_확인() {
@@ -126,6 +166,14 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
     }
     
     func test_when_댓글_싫어요_취소_성공_then_댓글_데이터_변화_확인() {
+        
+    }
+    
+    func test_when_유저가_댓글_작성자인_경우_then_닉네임_작성자로_표시() {
+        
+    }
+    
+    func test_when_유저가_댓글_작성자가_아닌_경우_then_닉네임_활용() {
         
     }
     

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -15,35 +15,33 @@ import Data
 
 final class CommentBottomSheetViewModelTests: XCTestCase {
 
-    private var commentBottomSheetViewModel: CommentBottomSheetViewModel!
     private let commentRepository: CommentRepository = DefaultCommentRepository()
     private var cancellable: Set<AnyCancellable> = []
-    
-    override func setUp() {
-        self.commentBottomSheetViewModel = DefaultCommentBottomSheetViewModel(
-            topicId: 0,
-            choices: mockTextChoices,
-            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
-            fetchCommentsUseCase: MockFetchCommentsUseCase(.success),
-            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
-            patchCommentLikeUseCase: DefaultPatchCommentLikeStateUseCase(repository: commentRepository),
-            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
-            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
-        )
-    }
     
     func test_when_댓글_조회_성공_then_데이터_재로드() {
         
         let expectation = expectation(description: "댓글 조회 성공 이후, reloadData가 실행되는지 확인")
         
         //given
-        guard var sut = commentBottomSheetViewModel else  { return }
+        let fetchCommentsUseCase = MockFetchCommentsUseCase(.success)
+        fetchCommentsUseCase.paging = Paging(page: 0, size: fetchCommentsUseCase.comments.count, isEmpty: false, last: true)
+        let sut = DefaultCommentBottomSheetViewModel(
+            topicId: 0,
+            choices: mockTextChoices,
+            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
+            fetchCommentsUseCase: fetchCommentsUseCase,
+            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
+            patchCommentLikeUseCase: DefaultPatchCommentLikeStateUseCase(repository: commentRepository),
+            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
+            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
+        )
         sut.reloadData = {
             //then
             defer {
                 expectation.fulfill()
             }
             XCTAssertTrue(sut.comments.count > 0)
+            XCTAssertEqual(sut.comments.count, fetchCommentsUseCase.comments.count)
             XCTAssertEqual(sut.currentPage, 0)
         }
         

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -1,0 +1,55 @@
+//
+//  CommentBottomSheetViewModelTests.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import XCTest
+import Combine
+import CommentFeature
+import CommentFeatureInterface
+import Domain
+import Data
+
+final class CommentBottomSheetViewModelTests: XCTestCase {
+
+    private var commentBottomSheetViewModel: CommentBottomSheetViewModel!
+    private let commentRepository: CommentRepository = DefaultCommentRepository()
+    private var cancellable: Set<AnyCancellable> = []
+    
+    override func setUp() {
+        self.commentBottomSheetViewModel = DefaultCommentBottomSheetViewModel(
+            topicId: 0,
+            choices: mockTextChoices,
+            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
+            fetchCommentsUseCase: MockFetchCommentsUseCase(.success),
+            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
+            patchCommentLikeUseCase: DefaultPatchCommentLikeStateUseCase(repository: commentRepository),
+            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
+            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
+        )
+    }
+    
+    func test_when_댓글_조회_성공_then_데이터_재로드() {
+        
+        let expectation = expectation(description: "댓글 조회 성공 이후, reloadData가 실행되는지 확인")
+        
+        //given
+        guard var sut = commentBottomSheetViewModel else  { return }
+        sut.reloadData = {
+            //then
+            defer {
+                expectation.fulfill()
+            }
+            XCTAssertTrue(sut.comments.count > 0)
+            XCTAssertEqual(sut.currentPage, 0)
+        }
+        
+        //when
+        sut.fetchComments()
+        
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -12,36 +12,62 @@ import CommentFeature
 import CommentFeatureInterface
 import Domain
 import Data
+import Core
 
 final class CommentBottomSheetViewModelTests: XCTestCase {
 
+    private var commentBottomSheetViewModel: CommentBottomSheetViewModel!
+    private let fetchCommentsUseCase: MockFetchCommentsUseCase = MockFetchCommentsUseCase()
+    private let patchLikeUseCase: MockPatchCommentLikeStateUseCase = MockPatchCommentLikeStateUseCase()
     private let commentRepository: CommentRepository = DefaultCommentRepository()
     private var cancellable: Set<AnyCancellable> = []
+    
+    
+    override func setUp() {
+        
+        setDefaultComments()
+        setDefaultPaging()
+        
+        self.commentBottomSheetViewModel = DefaultCommentBottomSheetViewModel(
+            topicId: 0,
+            choices: mockTextChoices,
+            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
+            fetchCommentsUseCase: self.fetchCommentsUseCase,
+            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
+            patchCommentLikeUseCase: self.patchLikeUseCase,
+            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
+            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
+        )
+        
+        func setDefaultPaging() {
+            fetchCommentsUseCase.paging = Paging(
+                page: 0, size: fetchCommentsUseCase.comments.count, isEmpty: false, last: false
+            )
+        }
+        
+        func setDefaultComments() {
+            fetchCommentsUseCase.comments = [
+                .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
+                .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current)
+            ]
+        }
+    }
     
     func test_when_댓글_조회_성공_then_데이터_재로드() {
         
         let expectation = expectation(description: "댓글 조회 성공 이후, reloadData가 실행되는지 확인")
         
         //given
-        let fetchCommentsUseCase = MockFetchCommentsUseCase(.success)
-        fetchCommentsUseCase.paging = Paging(page: 0, size: fetchCommentsUseCase.comments.count, isEmpty: false, last: true)
-        let sut = DefaultCommentBottomSheetViewModel(
-            topicId: 0,
-            choices: mockTextChoices,
-            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
-            fetchCommentsUseCase: fetchCommentsUseCase,
-            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
-            patchCommentLikeUseCase: DefaultPatchCommentLikeStateUseCase(repository: commentRepository),
-            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
-            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
-        )
+        fetchCommentsUseCase.mockType = .success
+        
+        guard var sut = commentBottomSheetViewModel else { return }
         sut.reloadData = {
             //then
             defer {
                 expectation.fulfill()
             }
             XCTAssertTrue(sut.comments.count > 0)
-            XCTAssertEqual(sut.comments.count, fetchCommentsUseCase.comments.count)
+            XCTAssertEqual(sut.comments.count, self.fetchCommentsUseCase.comments.count)
             XCTAssertEqual(sut.currentPage, 0)
         }
         
@@ -56,18 +82,9 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         let expectation = expectation(description: "마지막 페이지가 아닌 경우, 조건 검사 후 다음 페이지 요청하며 페이지 수와 댓글 개수 증가 확인")
         
         //given
-        let fetchCommentsUseCase = MockFetchCommentsUseCase(.success)
-        fetchCommentsUseCase.paging = Paging(page: 0, size: fetchCommentsUseCase.comments.count, isEmpty: false, last: false)
-        let sut = DefaultCommentBottomSheetViewModel(
-            topicId: 0,
-            choices: mockTextChoices,
-            generateCommentUseCase: DefaultGenerateCommentUseCase(repository: commentRepository),
-            fetchCommentsUseCase: fetchCommentsUseCase,
-            patchCommentUseCase: DefaultPatchCommentUseCase(repository: commentRepository),
-            patchCommentLikeUseCase: DefaultPatchCommentLikeStateUseCase(repository: commentRepository),
-            patchCommentDislikeUseCase: DefaultPatchCommentDislikeStateUseCase(repository: commentRepository),
-            deleteCommentUseCase: DefaultDeleteCommentUseCase(repository: commentRepository)
-        )
+        fetchCommentsUseCase.mockType = .success
+        
+        guard var sut = commentBottomSheetViewModel else { return }
         
         //첫 번째 페이지 요청은 무시한다
         var requestNextPage = false
@@ -77,7 +94,8 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
                 defer {
                     expectation.fulfill()
                 }
-                XCTAssertEqual(sut.comments.count, fetchCommentsUseCase.comments.count*2)
+                XCTAssertTrue(sut.comments.count > 0)
+                XCTAssertEqual(sut.comments.count, self.fetchCommentsUseCase.comments.count*2)
                 XCTAssertEqual(sut.currentPage, 1)
             }
         }
@@ -91,5 +109,35 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         }
         
         waitForExpectations(timeout: 10)
+    }
+    
+    func test_when_댓글_좋아요_성공_then_댓글_데이터_변화_확인() {
+        //given
+        patchLikeUseCase.mockType = .success
+        guard let sut = commentBottomSheetViewModel else { return }
+    }
+    
+    func test_when_댓글_좋아요_취소_성공_then_댓글_데이터_변화_확인() {
+        
+    }
+    
+    func test_when_댓글_싫어요_성공_then_댓글_데이터_변화_확인() {
+        
+    }
+    
+    func test_when_댓글_싫어요_취소_성공_then_댓글_데이터_변화_확인() {
+        
+    }
+    
+    func test_when_댓글_생성_성공_then_댓글_0번째_인덱스_추가_확인() {
+        
+    }
+    
+    func test_when_댓글_수정_성공_then_댓글_데이터_변화_확인() {
+        
+    }
+    
+    func test_when_댓글_삭제_성공_then_댓글_데이터_변화_확인() {
+        
     }
 }

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -51,9 +51,9 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
     
-    func test_when_다음_페이지가_존재하는_경우_then_새로운_페이지_요청() {
+    func test_when_다음_페이지가_존재하는_경우_새로운_페이지_요청_성공_then_페이지와_댓글_데이터_변화() {
         
-        let expectation = expectation(description: "마지막 페이지가 아닌 경우, 조건 검사 후 다음 페이지 요청")
+        let expectation = expectation(description: "마지막 페이지가 아닌 경우, 조건 검사 후 다음 페이지 요청하며 페이지 수와 댓글 개수 증가 확인")
         
         //given
         let fetchCommentsUseCase = MockFetchCommentsUseCase(.success)

--- a/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
+++ b/Projects/Features/CommentFeature/Tests/CommentBottomSheetViewModelTests.swift
@@ -48,8 +48,8 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         
         func setDefaultComments() {
             fetchCommentsUseCase.comments = [
-                .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
-                .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 1, hateCount: 1, isLike: true, isHate: true, createdAt: UTCTime.current)
+                .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), votedOption: .A, content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
+                .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), votedOption: .B, content: "댓글1", likeCount: 1, hateCount: 1, isLike: true, isHate: true, createdAt: UTCTime.current)
             ]
         }
     }
@@ -217,12 +217,36 @@ final class CommentBottomSheetViewModelTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
     
-    func test_when_유저가_댓글_작성자인_경우_then_닉네임_작성자로_표시() {
+    func test_when_유저가_댓글_작성자인_경우_then_선택지_작성자로_표시() {
+         
+        //given
+        fetchCommentsUseCase.mockType = .success
         
+        guard let sut = commentBottomSheetViewModel else { return }
+        sut.fetchComments()
+        
+        //when
+        UserManager.shared.memberId = 0
+        
+        //then
+        XCTAssertEqual(sut.comments[0].selectedOption.option, nil)
+        XCTAssertEqual(sut.comments[0].selectedOption.content, "작성자")
     }
     
-    func test_when_유저가_댓글_작성자가_아닌_경우_then_닉네임_활용() {
+    func test_when_유저가_댓글_작성자가_아닌_경우_then_선택지_데이터_확인() {
         
+        //given
+        fetchCommentsUseCase.mockType = .success
+        
+        guard let sut = commentBottomSheetViewModel else { return }
+        sut.fetchComments()
+        
+        //when
+        UserManager.shared.memberId = 0
+        
+        //then
+        XCTAssertTrue(sut.comments[1].selectedOption.option != nil)
+        XCTAssertTrue(sut.comments[1].selectedOption.content.starts(with: "B."))
     }
     
     func test_when_댓글_생성_성공_then_댓글_0번째_인덱스_추가_확인() {

--- a/Projects/Features/CommentFeature/Tests/Mock/MockChoice.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockChoice.swift
@@ -1,0 +1,20 @@
+//
+//  MockChoice.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Domain
+
+let mockTextChoices: [Choice] = [
+    .init(id: 0, content: .init(text: "CHOICE_A", imageURL: nil), option: .A),
+    .init(id: 1, content: .init(text: "CHOICE_B", imageURL: nil), option: .B)
+]
+
+let mockImageChoices: [Choice] = [
+    .init(id: 0, content: .init(text: "CHOICE_A", imageURL: URL(string:"http://ab/choiceA")), option: .A),
+    .init(id: 1, content: .init(text: "CHOICE_B", imageURL: URL(string:"http://ab/choiceB")), option: .B)
+]

--- a/Projects/Features/CommentFeature/Tests/Mock/MockDeleteCommentUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockDeleteCommentUseCase.swift
@@ -1,0 +1,46 @@
+//
+//  MockDeleteCommentUseCase.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Combine
+
+final class MockDeleteCommentUseCase: DeleteCommentUseCase {
+    
+    init(){
+        
+    }
+    
+    init(repository: CommentRepository) {
+        fatalError()
+    }
+    
+    var mockType: MOCKType!
+    
+    func execute(commentId: Int) -> NetworkResultPublisher<Any?> {
+        switch mockType {
+        case .success:
+            return Just((
+                isSuccess: true,
+                data: Optional<Any>(nil),
+                error: Optional<ErrorContent>(nil))
+            ).eraseToAnyPublisher()
+            
+        case .failure:
+            return Just((
+                isSuccess: false,
+                data: Optional<Comment>(nil),
+                error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
+            )).eraseToAnyPublisher()
+            
+        default:
+            fatalError()
+        }
+    }
+}
+

--- a/Projects/Features/CommentFeature/Tests/Mock/MockFetchCommentsUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockFetchCommentsUseCase.swift
@@ -22,8 +22,11 @@ final class MockFetchCommentsUseCase: FetchCommentsUseCase {
     }
     
     private let mockType: MOCKType
-    private let paging = Paging(page: 0, size: 50, isEmpty: false, last: false)
-    private let comments: [Comment] = [
+    
+    //MARK: Output
+    
+    var paging: Paging!
+    let comments: [Comment] = [
         .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
         .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current)
     ]

--- a/Projects/Features/CommentFeature/Tests/Mock/MockFetchCommentsUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockFetchCommentsUseCase.swift
@@ -1,0 +1,48 @@
+//
+//  MockFetchCommentsUseCase.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Domain
+import Core
+
+final class MockFetchCommentsUseCase: FetchCommentsUseCase {
+    
+    init(_ type: MOCKType){
+        self.mockType = type
+    }
+    
+    init(repository: CommentRepository) {
+        fatalError()
+    }
+    
+    private let mockType: MOCKType
+    private let paging = Paging(page: 0, size: 50, isEmpty: false, last: false)
+    private let comments: [Comment] = [
+        .init(commentId: 0, topicId: 0, writer: .init(id: 0, nickname: "A", profileImageURl: nil), content: "작성자 댓글", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current),
+        .init(commentId: 1, topicId: 0, writer: .init(id: 1, nickname: "B", profileImageURl: nil), content: "댓글1", likeCount: 0, hateCount: 0, isLike: false, isHate: false, createdAt: UTCTime.current)
+    ]
+    
+    func execute(topicId: Int, page: Int) -> NetworkResultPublisher<(Paging, [Comment])?> {
+        switch mockType {
+        case .success:
+            return AnyPublisher(Just((
+                isSuccess: true,
+                data: Optional((paging, comments)),
+                error: Optional<ErrorContent>(nil))
+            ))
+            
+        case .failure:
+            return AnyPublisher(Just((
+                isSuccess: false,
+                data: Optional<(Paging, [Comment])>(nil),
+                error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
+            )))
+        }
+    }
+}

--- a/Projects/Features/CommentFeature/Tests/Mock/MockGenerateCommentUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockGenerateCommentUseCase.swift
@@ -1,0 +1,47 @@
+//
+//  MockGenerateCommentUseCase.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Combine
+
+final class MockGenerateCommentUseCase: GenerateCommentUseCase {
+    
+    init(){
+        
+    }
+    
+    init(repository: CommentRepository) {
+        fatalError()
+    }
+    
+    var comment: Comment!
+    var mockType: MOCKType!
+    
+    func execute(request: GenerateCommentUseCaseRequestValue) -> NetworkResultPublisher<Comment?> {
+        switch mockType {
+        case .success:
+            return Just((
+                isSuccess: true,
+                data: Optional<Comment>(comment),
+                error: Optional<ErrorContent>(nil))
+            ).eraseToAnyPublisher()
+            
+        case .failure:
+            return Just((
+                isSuccess: false,
+                data: Optional<Comment>(nil),
+                error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
+            )).eraseToAnyPublisher()
+            
+        default:
+            fatalError()
+        }
+    }
+}
+

--- a/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentDislikeStateUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentDislikeStateUseCase.swift
@@ -1,0 +1,45 @@
+//
+//  MockPatchCommentDislikeStateUseCase.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Combine
+
+final class MockPatchCommentDislikeStateUseCase: PatchCommentDislikeStateUseCase {
+    
+    init(){
+        
+    }
+    
+    init(repository: CommentRepository) {
+        fatalError()
+    }
+    
+    var mockType: MOCKType!
+    
+    func execute(commentId: Int, isDislike: Bool) -> NetworkResultPublisher<Any?> {
+        switch mockType {
+        case .success:
+            return Just((
+                isSuccess: true,
+                data: Optional<Any>(nil),
+                error: Optional<ErrorContent>(nil))
+            ).eraseToAnyPublisher()
+            
+        case .failure:
+            return Just((
+                isSuccess: false,
+                data: Optional<Any>(nil),
+                error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
+            )).eraseToAnyPublisher()
+            
+        default:
+            fatalError()
+        }
+    }
+}

--- a/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentLikeStateUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentLikeStateUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  MockFetchCommentsUseCase.swift
+//  MockPatchCommentLikeStateUseCase.swift
 //  CommentFeatureTests
 //
 //  Created by 박소윤 on 2024/01/09.
@@ -7,12 +7,12 @@
 //
 
 import Foundation
-import Combine
 import Domain
+import Combine
 
-final class MockFetchCommentsUseCase: FetchCommentsUseCase {
+final class MockPatchCommentLikeStateUseCase: PatchCommentLikeStateUseCase {
     
-    init() {
+    init(){
         
     }
     
@@ -20,30 +20,23 @@ final class MockFetchCommentsUseCase: FetchCommentsUseCase {
         fatalError()
     }
     
-    //MARK: Input
-    
     var mockType: MOCKType!
     
-    //MARK: Output
-    
-    var paging: Paging!
-    var comments: [Comment]!
-    
-    func execute(topicId: Int, page: Int) -> NetworkResultPublisher<(Paging, [Comment])?> {
+    func execute(commentId: Int, isLike: Bool) -> NetworkResultPublisher<Any?> {
         switch mockType {
         case .success:
-            return AnyPublisher(Just((
+            return Just((
                 isSuccess: true,
-                data: Optional((paging, comments)),
+                data: Optional<Any>(nil),
                 error: Optional<ErrorContent>(nil))
-            ))
+            ).eraseToAnyPublisher()
             
         case .failure:
-            return AnyPublisher(Just((
+            return Just((
                 isSuccess: false,
-                data: Optional<(Paging, [Comment])>(nil),
+                data: Optional<Any>(nil),
                 error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
-            )))
+            )).eraseToAnyPublisher()
             
         default:
             fatalError()

--- a/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentUseCase.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockPatchCommentUseCase.swift
@@ -1,0 +1,47 @@
+//
+//  MockPatchCommentUseCase.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Combine
+
+final class MockPatchCommentUseCase: PatchCommentUseCase {
+    
+    init(){
+        
+    }
+    
+    init(repository: CommentRepository) {
+        fatalError()
+    }
+    
+    var comment: Comment!
+    var mockType: MOCKType!
+    
+    func execute(commentId: Int, request: PatchCommentUseCaseRequestValue) -> NetworkResultPublisher<Comment?> {
+        switch mockType {
+        case .success:
+            return Just((
+                isSuccess: true,
+                data: Optional<Comment>(comment),
+                error: Optional<ErrorContent>(nil))
+            ).eraseToAnyPublisher()
+            
+        case .failure:
+            return Just((
+                isSuccess: false,
+                data: Optional<Comment>(nil),
+                error: Optional<ErrorContent>(ErrorContent(code: .emptyAuthorization, message: "통신 에러"))
+            )).eraseToAnyPublisher()
+            
+        default:
+            fatalError()
+        }
+    }
+}
+

--- a/Projects/Features/CommentFeature/Tests/Mock/MockType.swift
+++ b/Projects/Features/CommentFeature/Tests/Mock/MockType.swift
@@ -1,0 +1,13 @@
+//
+//  MockType.swift
+//  CommentFeatureTests
+//
+//  Created by 박소윤 on 2024/01/09.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+
+enum MOCKType {
+    case success, failure
+}

--- a/Projects/Features/CommentFeature/Tests/Test.swift
+++ b/Projects/Features/CommentFeature/Tests/Test.swift
@@ -1,8 +1,0 @@
-//
-//  Test.swift
-//  ProjectDescriptionHelpers
-//
-//  Created by 박소윤 on 2024/01/08.
-//
-
-import Foundation


### PR DESCRIPTION
### 댓글 바텀시트 View Model 테스트 코드 작성
- 서비스의 안정성을 높이기 위해, 테스트 코드를 작성하였습니다. View Model 내에서 상태 변화가 정상적으로 이뤄지는지 확인하는 것을 목표로 하였습니다. 
---
close #86