### PR TITLE
[FEATURE] #130: 토픽 댓글 프리뷰 기능 구현

### DIFF
--- a/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
+++ b/Projects/Data/Sources/Repository/DefaultTopicRepository.swift
@@ -175,4 +175,16 @@ public final class DefaultTopicRepository: TopicRepository {
             .init(modifiedOption: request.modifiedOption.toDTO(), modifiedAt: request.modifiedAt)
         }
     }
+    
+    public func fetchCommentPreview(topicId: Int) -> NetworkResultPublisher<Comment?> {
+        
+        var urlComponents = networkService.baseUrlComponents
+        urlComponents?.path = basePath + path(topicId) + path("comment")
+        
+        guard let urlRequest = urlComponents?.toURLRequest(method: .get) else {
+            fatalError("json encoding or url parsing error")
+        }
+        
+        return dataTask(request: urlRequest, responseType: CommentResponseDTO.self)
+    }
 }

--- a/Projects/Domain/Sources/RepositoryInterface/TopicRepository.swift
+++ b/Projects/Domain/Sources/RepositoryInterface/TopicRepository.swift
@@ -15,4 +15,5 @@ public protocol TopicRepository: Repository{
     func report(topicId: Int) -> NetworkResultPublisher<Any?>
     func vote(topicId: Int, request: GenerateVoteUseCaseRequestValue) -> NetworkResultPublisher<(Topic, Comment?)?>
     func revote(topicId: Int, request: RevoteUseCaseRequestValue) -> NetworkResultPublisher<(Topic, Comment?)?>
+    func fetchCommentPreview(topicId: Int) -> NetworkResultPublisher<Comment?>
 }

--- a/Projects/Domain/Sources/UseCase/Topic/FetchCommentPreviewUseCase.swift
+++ b/Projects/Domain/Sources/UseCase/Topic/FetchCommentPreviewUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  FetchCommentPreviewUseCase.swift
+//  Domain
+//
+//  Created by 박소윤 on 2024/02/16.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+
+public protocol FetchCommentPreviewUseCase: UseCase {
+    func execute(topicId: Int) -> NetworkResultPublisher<Comment?>
+}
+
+public final class DefaultFetchCommentPreviewUseCase: FetchCommentPreviewUseCase {
+
+    private let repository: TopicRepository
+    
+    public init(repository: TopicRepository) {
+        self.repository = repository
+    }
+    
+    public func execute(topicId: Int) -> NetworkResultPublisher<Comment?> {
+        repository.fetchCommentPreview(topicId: topicId)
+    }
+}

--- a/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
@@ -12,20 +12,13 @@ import Domain
 import TopicFeatureInterface
 import FeatureDependency
 
-public protocol HomeTabViewModel: AnyObject, TopicPageControlViewModel, TimerControlViewModel, TopicVoteViewModel, TopicBottomSheetViewModel, ErrorHandleable {
+public protocol HomeTabViewModel: AnyObject, TopicPageControlViewModel, TimerControlViewModel, VoteTopicViewModel, RevoteTopicViewModel, TopicBottomSheetViewModel, ErrorHandleable {
     var currentTopic: TopicDetailItemViewModel { get }
     func viewDidLoad()
 }
 
-public protocol TopicVoteViewModel {
-    var successVote: PassthroughSubject<Choice.Option, Never> { get }
-    var failVote: PassthroughSubject<Void, Never> { get }
-    func vote(_ option: Choice.Option)
-    func revote(_ option: Choice.Option)
-}
-
 public protocol TopicPageControlViewModel {
-    var topics: [TopicDetailItemViewModel] { get }
+    var topics: [TopicItemViewModel] { get }
     var canMovePrevious: Bool { get }
     var canMoveNext: Bool { get }
     var willMovePage: AnyPublisher<IndexPath, Never> { get }

--- a/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
+++ b/Projects/Features/HomeFeature/Interface/ViewModel/HomeTabViewModel.swift
@@ -12,7 +12,7 @@ import Domain
 import TopicFeatureInterface
 import FeatureDependency
 
-public protocol HomeTabViewModel: AnyObject, TopicPageControlViewModel, TimerControlViewModel, VoteTopicViewModel, RevoteTopicViewModel, TopicBottomSheetViewModel, ErrorHandleable {
+public protocol HomeTabViewModel: AnyObject, TopicPageControlViewModel, TimerControlViewModel, VoteTopicViewModel, RevoteTopicViewModel, TopicBottomSheetViewModel, FetchCommentPreviewViewModel, ErrorHandleable {
     var currentTopic: TopicDetailItemViewModel { get }
     func viewDidLoad()
 }

--- a/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
+++ b/Projects/Features/HomeFeature/Sources/DefaultHomeCoordinator.swift
@@ -40,7 +40,8 @@ public class DefaultHomeCoordinator: HomeCoordinator {
             fetchTopicsUseCase: getFetchTopicsUseCase(),
             reportTopicUseCase: getReportTopicUseCase(),
             voteTopicUseCase: getVoteTopicUseCase(),
-            revoteTopicUseCase: getRevoteTopicUseCase()
+            revoteTopicUseCase: getRevoteTopicUseCase(),
+            fetchCommentPreviewUseCase: getFetchCommentPreviewUseCase()
         )
         
         func getFetchTopicsUseCase() -> any FetchTopicsUseCase {
@@ -57,6 +58,10 @@ public class DefaultHomeCoordinator: HomeCoordinator {
         
         func getRevoteTopicUseCase() -> any RevoteUseCase {
             DefaultRevoteUseCase(repository: topicRepository)
+        }
+        
+        func getFetchCommentPreviewUseCase() -> any FetchCommentPreviewUseCase {
+            DefaultFetchCommentPreviewUseCase(repository: topicRepository)
         }
     }
     

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -144,7 +144,7 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         func bindVoteSuccess() {
             viewModel.successVote
                 .receive(on: DispatchQueue.main)
-                .sink{ [weak self] choice in
+                .sink{ [weak self] index, choice in
                     guard let self = self else { return }
                     self.currentTopicCell?.select(choice: self.viewModel.currentTopic.choices[choice]!)
                 }
@@ -176,7 +176,7 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         func bindFailVote() {
             viewModel.failVote
                 .receive(on: DispatchQueue.main)
-                .sink{ [weak self] in
+                .sink{ [weak self] index in
                     guard let self = self else { return }
                     self.currentTopicCell?.failVote()
                 }
@@ -195,7 +195,7 @@ extension HomeTabViewController: UICollectionViewDelegate, UICollectionViewDataS
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: TopicDetailCollectionViewCell.self)
         cell.delegate = self
-        cell.binding(data: viewModel.topics[indexPath.row])
+        cell.binding(data: .init(topic: viewModel.topics[indexPath.row].topic))
         return cell
     }
     
@@ -205,8 +205,6 @@ extension HomeTabViewController: UICollectionViewDelegate, UICollectionViewDataS
     
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         currentTopicCell = cell as? TopicDetailCollectionViewCell
-        //셀이 다시 보여질 때마다 재로드 시킨다
-        currentTopicCell?.binding(data: viewModel.topics[indexPath.row])
     }
 }
 
@@ -231,11 +229,12 @@ extension HomeTabViewController: ChatBottomSheetDelegate, TopicBottomSheetDelega
 extension HomeTabViewController: VoteDelegate {
     func vote(_ option: Choice.Option, index: Int?) {
         print(option)
+        guard let index = index else { return }
         if viewModel.currentTopic.isVoted {
-            viewModel.revote(option)
+            viewModel.revote(option, index: index)
         }
         else {
-            viewModel.vote(option)
+            viewModel.vote(option, index: index)
         }
     }
 }

--- a/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewController/HomeTabViewController.swift
@@ -56,7 +56,7 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         setDelegate()
         moveAlarm()
         addButtonFrameTarget()
-        addRevoteNotification()
+        previousVisibility()
         
         func setDelegate(){
             mainView.scrollFrame.setDelegate(to: self)
@@ -82,18 +82,8 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
                 }.store(in: &cancellables)
         }
         
-        func addRevoteNotification() {
-            NotificationCenter.default.publisher(for: Notification.Name(Topic.Action.revote.identifier), object: viewModel)
-                .receive(on: DispatchQueue.main)
-                .sink{ [weak self] _ in
-                    guard let self = self else { return }
-                    // 1. 토스트 메시지 보여주기
-                    ToastMessage.shared.register(message: "다시 선택하면, 해당 토픽에 작성한 댓글이 삭제돼요")
-                    // 2. 선택지 다시 보여주기
-                    self.currentTopicCell?.clearVote()
-                    
-                }
-                .store(in: &cancellables)
+        func previousVisibility() {
+            mainView.scrollFrame.buttonFrame.previousButton.isHidden = true
         }
     }
     
@@ -107,6 +97,7 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
         bindVoteSuccess()
         bindImageExpandNotification()
         bindFailVote()
+        bindRevoteNotification()
         
         func bindError() {
             viewModel.errorHandler
@@ -179,6 +170,20 @@ final class HomeTabViewController: BaseViewController<HeaderView, HomeTabView, D
                 .sink{ [weak self] index in
                     guard let self = self else { return }
                     self.currentTopicCell?.failVote()
+                }
+                .store(in: &cancellables)
+        }
+        
+        func bindRevoteNotification() {
+            NotificationCenter.default.publisher(for: Notification.Name(Topic.Action.revote.identifier), object: viewModel)
+                .receive(on: DispatchQueue.main)
+                .sink{ [weak self] _ in
+                    guard let self = self else { return }
+                    // 1. 토스트 메시지 보여주기
+                    ToastMessage.shared.register(message: "다시 선택하면, 해당 토픽에 작성한 댓글이 삭제돼요")
+                    // 2. 선택지 다시 보여주기
+                    self.currentTopicCell?.clearVote()
+                    
                 }
                 .store(in: &cancellables)
         }

--- a/Projects/Features/HomeFeature/Sources/ViewModel/DefaultHomeTabViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModel/DefaultHomeTabViewModel.swift
@@ -20,17 +20,20 @@ final class DefaultHomeTabViewModel: BaseViewModel, HomeTabViewModel {
     private let reportTopicUseCase: any ReportTopicUseCase
     let voteTopicUseCase: any GenerateVoteUseCase
     let revoteTopicUseCase: any RevoteUseCase
+    let fetchCommentPreviewUseCase: any FetchCommentPreviewUseCase
     
     init(
         fetchTopicsUseCase: any FetchTopicsUseCase,
         reportTopicUseCase: any ReportTopicUseCase,
         voteTopicUseCase: any GenerateVoteUseCase,
-        revoteTopicUseCase: any RevoteUseCase
+        revoteTopicUseCase: any RevoteUseCase,
+        fetchCommentPreviewUseCase: any FetchCommentPreviewUseCase
     ) {
         self.fetchTopicsUseCase = fetchTopicsUseCase
         self.reportTopicUseCase = reportTopicUseCase
         self.voteTopicUseCase = voteTopicUseCase
         self.revoteTopicUseCase = revoteTopicUseCase
+        self.fetchCommentPreviewUseCase = fetchCommentPreviewUseCase
         super.init()
     }
 
@@ -48,6 +51,7 @@ final class DefaultHomeTabViewModel: BaseViewModel, HomeTabViewModel {
     let timerSubject: PassthroughSubject<TimerInfo, Never> = PassthroughSubject()
     let errorHandler: PassthroughSubject<ErrorContent, Never> = PassthroughSubject()
     let successTopicAction: PassthroughSubject<Topic.Action, Never> = PassthroughSubject()
+    let reloadItem: PassthroughSubject<Index, Never> = PassthroughSubject()
     
     private var timer: Timer?
     

--- a/Projects/Features/TopicFeature/Interface/ViewModel/FetchCommentPreviewViewModel.swift
+++ b/Projects/Features/TopicFeature/Interface/ViewModel/FetchCommentPreviewViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  FetchCommentPreviewViewModel.swift
+//  TopicFeatureInterface
+//
+//  Created by 박소윤 on 2024/02/16.
+//  Copyright © 2024 AB. All rights reserved.
+//
+
+import Foundation
+import FeatureDependency
+import Domain
+import Combine
+import Core
+
+public protocol FetchCommentPreviewViewModel: BaseViewModel, ErrorHandleable {
+    var topics: [TopicItemViewModel] { get set }
+    var fetchCommentPreviewUseCase: any FetchCommentPreviewUseCase { get }
+    var reloadItem: PassthroughSubject<Index, Never> { get }
+    func fetchCommentPreview(index: Int)
+}
+
+extension FetchCommentPreviewViewModel {
+    public func fetchCommentPreview(index: Int) {
+        fetchCommentPreviewUseCase.execute(topicId: topics[index].id)
+            .sink{ [weak self] result in
+                if result.isSuccess, let comment = result.data {
+                    defer {
+                        self?.reloadItem.send(index)
+                    }
+                    self?.topics[index].commentPreview = comment
+                }
+                else if let error = result.error {
+                    self?.errorHandler.send(error)
+                }
+            }
+            .store(in: &cancellable)
+    }
+}

--- a/Projects/Features/TopicFeature/Interface/ViewModel/TopicDetailItemViewModel.swift
+++ b/Projects/Features/TopicFeature/Interface/ViewModel/TopicDetailItemViewModel.swift
@@ -11,6 +11,7 @@ import Domain
 import Core
 
 public struct TopicDetailItemViewModel {
+    public let isCommentEmpty: Bool
     public let id: Int
     public let title: String
     public let nickname: String
@@ -38,6 +39,7 @@ extension TopicDetailItemViewModel {
         self.voteCount = ABFormat.count(topic.voteCount) + " 명"
         self.votedOption = topic.selectedOption
         self.choices = topic.choices
+        self.isCommentEmpty = topic.commentCount == 0
     }
     
     public var isVoted: Bool {

--- a/Projects/Features/TopicFeature/Sources/Cell/Frame/ChoiceView.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/Frame/ChoiceView.swift
@@ -97,11 +97,13 @@ extension TopicDetailCollectionViewCell {
         }
         
         func removeContent() {
+            content?.views.forEach{
+                $0.removeFromSuperview()
+            }
             content = nil
         }
         
         func fill(_ choice: Choice) {
-
             content = {
                 if choice.content.imageURL == nil {
                     return TextChoiceContent(choice: choice)

--- a/Projects/Features/TopicFeature/Sources/Cell/Frame/CommentView.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/Frame/CommentView.swift
@@ -9,19 +9,11 @@
 import Foundation
 import UIKit
 import ABKit
+import Domain
 
 extension TopicDetailCollectionViewCell {
     
     public final class CommentView: BaseView {
-        
-        var canUserInteraction = false {
-            didSet {
-                [blurView, induceSelectChip].forEach{
-                    $0.isHidden = canUserInteraction
-                }
-                isUserInteractionEnabled = canUserInteraction
-            }
-        }
         
         private let headerFrame: UIView = {
             let view = UIView()
@@ -39,6 +31,13 @@ extension TopicDetailCollectionViewCell {
             label.setTypo(Pretendard.bold15)
             label.layer.cornerRadius = 29/2
             label.layer.masksToBounds = true
+            return label
+        }()
+        private let induceWriteCommentLabel: UILabel = {
+           let label = UILabel()
+            label.text = "선택 후 가장 먼저 댓글을 작성해 보세요!"
+            label.setTypo(Pretendard.regular14)
+            label.textColor = Color.white60
             return label
         }()
         private let countStackView: UIStackView = UIStackView(axis: .horizontal, spacing: 12)
@@ -64,7 +63,7 @@ extension TopicDetailCollectionViewCell {
                 countStackView.addArrangedSubviews([chatCountFrame, likeCountFrame])
             }
             func content() {
-                contentFrame.addSubviews([contentCell, blurView, induceSelectChip])
+                contentFrame.addSubviews([induceWriteCommentLabel, contentCell, blurView, induceSelectChip])
             }
         }
         public override func layout() {
@@ -103,7 +102,45 @@ extension TopicDetailCollectionViewCell {
                     $0.top.bottom.equalToSuperview().inset(14)
                     $0.leading.trailing.equalToSuperview()
                 }
+                induceWriteCommentLabel.snp.makeConstraints{
+                    $0.center.equalToSuperview()
+                }
             }
+        }
+        
+        ///댓글 개수가 0인 경우
+        public func empty() {
+            induceWriteCommentLabel.isHidden = false
+            chatCountFrame.isHidden = true
+            contentCell.isHidden = true
+            [blurView, induceSelectChip].forEach{
+                $0.isHidden = true
+            }
+            isUserInteractionEnabled = false
+        }
+        
+        public func fill(comment: Comment?, isVoted: Bool) {
+            let (subviewHidden,isInteractionEnabled) = {
+                if comment == nil {
+                    return (true, false)
+                }
+                else if isVoted {
+                    return (true, true)
+                }
+                else {
+                    return (false, false)
+                }
+            }()
+
+            contentCell.isHidden = false
+            chatCountFrame.isHidden = false
+            induceWriteCommentLabel.isHidden = true
+            [blurView, induceSelectChip].forEach{
+                $0.isHidden = subviewHidden
+            }
+            isUserInteractionEnabled = isInteractionEnabled
+//            contentCell.profileImageView.image =
+            contentCell.contentLabel.text = comment?.content
         }
     }
 }
@@ -112,14 +149,14 @@ extension TopicDetailCollectionViewCell.CommentView {
     
     final class RepresentativeCommentView: BaseView {
         
-        private let profileImageView: UIImageView = {
+        let profileImageView: UIImageView = {
             let imageView = UIImageView()
             imageView.layer.cornerRadius = 22/2
             imageView.layer.masksToBounds = true
             imageView.backgroundColor = UIColor(217)
             return imageView
         }()
-        private let contentLabel: UILabel = {
+        let contentLabel: UILabel = {
             let label = UILabel()
             label.text = "나는 10년 전 과거로 가서 주식..."
             label.setTypo(Pretendard.regular15)

--- a/Projects/Features/TopicFeature/Sources/Cell/Frame/CommentView.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/Frame/CommentView.swift
@@ -109,17 +109,18 @@ extension TopicDetailCollectionViewCell {
         }
         
         ///댓글 개수가 0인 경우
-        public func empty() {
+        public func empty(isVoted: Bool) {
             induceWriteCommentLabel.isHidden = false
             chatCountFrame.isHidden = true
             contentCell.isHidden = true
             [blurView, induceSelectChip].forEach{
                 $0.isHidden = true
             }
-            isUserInteractionEnabled = false
+            isUserInteractionEnabled = isVoted
         }
         
         public func fill(comment: Comment?, isVoted: Bool) {
+            
             let (subviewHidden,isInteractionEnabled) = {
                 if comment == nil {
                     return (true, false)
@@ -158,7 +159,6 @@ extension TopicDetailCollectionViewCell.CommentView {
         }()
         let contentLabel: UILabel = {
             let label = UILabel()
-            label.text = "나는 10년 전 과거로 가서 주식..."
             label.setTypo(Pretendard.regular15)
             label.textColor = Color.white
             return label

--- a/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
@@ -245,7 +245,7 @@ open class TopicDetailCollectionViewCell: BaseCollectionViewCell{
         topicGroup.timer.binding(data: timer)
     }
     
-    open func binding(data: TopicDetailItemViewModel) {
+    open func binding(data: TopicDetailItemViewModel, comment: Comment?) {
         if data.isVoted {
             guard let votedOption = data.votedOption, let votedChoice = data.choices[votedOption] else { return }
             select(choice: votedChoice)
@@ -262,6 +262,8 @@ open class TopicDetailCollectionViewCell: BaseCollectionViewCell{
         userGroup.nicknameLabel.text = data.nickname
         chat.chatCountFrame.binding(data.commentCount)
         chat.likeCountFrame.binding(data.voteCount)
+        
+        data.isCommentEmpty ? chat.empty() : chat.fill(comment: comment, isVoted: data.isVoted)
     }
 }
 
@@ -279,14 +281,10 @@ extension TopicDetailCollectionViewCell {
     }
     
     private func toggle(isVoted value: Bool) {
-        
         choiceGroup.completeView.isHidden = !value
-        
         [choiceGroup.slideExplainView, choiceStackView].forEach{
             $0.isHidden = value
         }
-        
-        chat.canUserInteraction = value
     }
     
     public func failVote() {

--- a/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
@@ -231,7 +231,7 @@ open class TopicDetailCollectionViewCell: BaseCollectionViewCell{
                 
                 func initializeChoiceView() {
                     choiceStackView.isHidden = true
-                    choiceStackView.center.x = center.x
+                    choiceStackView.frame.origin = originalPoint
                     choiceStackView.alpha = 1
                 }
             }

--- a/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
+++ b/Projects/Features/TopicFeature/Sources/Cell/TopicDetailCollectionViewCell.swift
@@ -263,7 +263,7 @@ open class TopicDetailCollectionViewCell: BaseCollectionViewCell{
         chat.chatCountFrame.binding(data.commentCount)
         chat.likeCountFrame.binding(data.voteCount)
         
-        data.isCommentEmpty ? chat.empty() : chat.fill(comment: comment, isVoted: data.isVoted)
+        data.isCommentEmpty ? chat.empty(isVoted: data.isVoted) : chat.fill(comment: comment, isVoted: data.isVoted)
     }
 }
 


### PR DESCRIPTION
### 댓글 프리뷰
토픽 페이지를 전환할 때, 댓글 개수가 0 이상이고 아직 프리뷰 데이터가 없는 경우 댓글 한 개 조회 API를 호출하도록 하였습니다. 

### 자잘자잘한 버그 해결
- 홈 탭 처음 로드시, 이전 버튼 숨기기
- 셀 재사용될 때, 이전 컨텐츠 컴포넌트 제거
- 투표 실패한 경우 원래 레이아웃으로 복구

### 홈 탭 공용 ViewModel 적용
투표, 재투표, 토픽 조회를 공용 ViewModel 프로토콜을 채택하였습니다. 

---
close #130