### PR TITLE
[FEATURE] #153: 텍스트 입력값 정규표현식으로 점검

### DIFF
--- a/Projects/ABKit/Sources/TextField/ABTextFieldView.swift
+++ b/Projects/ABKit/Sources/TextField/ABTextFieldView.swift
@@ -157,12 +157,15 @@ open class ABTextFieldView: BaseStackView {
     private func bindTextCount() {
         countLabel.text = "\(0)/\(limitCount!)"
         textField.publisher(for: .editingChanged)
-            .sink{ [weak self] in
+            .sink{ [weak self] text in
                 
                 guard let self = self, let limitCount = self.limitCount else { return }
                 
+                let limitString = String(text.prefix(limitCount))
+                
                 self.state = .editing
-                self.countLabel.text = "\($0.count)/\(limitCount)"
+                self.textField.text = limitString
+                self.countLabel.text = "\(limitString.count)/\(limitCount)"
             }
             .store(in: &cancellable)
     }

--- a/Projects/Core/Sources/Regex.swift
+++ b/Projects/Core/Sources/Regex.swift
@@ -22,12 +22,16 @@ public enum Regex {
 
 extension Regex {
     
-    public struct RegexConfiguration {
-        fileprivate let expression: String
-        public let limitCount: Int
+    public var limitCount: Int {
+        configuration.limitCount
     }
     
-    public var configuration: RegexConfiguration {
+    fileprivate struct RegexConfiguration {
+        fileprivate let expression: String
+        fileprivate let limitCount: Int
+    }
+    
+    fileprivate var configuration: RegexConfiguration {
         switch self {
         case .nickname:
             return .init(expression: "^[0-9a-zA-Z가-힣]{1,8}$", limitCount: 8)

--- a/Projects/Core/Sources/Regex.swift
+++ b/Projects/Core/Sources/Regex.swift
@@ -8,13 +8,35 @@
 
 import Foundation
 
-public struct Regex {
+public enum Regex {
     
-    public enum RegexPattern: String {
-        case nickname = "^[0-9a-zA-Z가-힣]{1,12}"
+    case nickname
+    case topicTitle //한글, 영문, 숫자, 특수문자 최대 20자 
+    case topicKeyword //한글, 영문, 숫자 최대 6자
+    case choiceContent //한글, 영문, 숫자, 특수문자 최대 25자 
+    
+    public static func validate(data: String, pattern: Regex) -> Bool {
+        data.range(of: pattern.configuration.expression, options: .regularExpression) != nil
+    }
+}
+
+extension Regex {
+    
+    public struct RegexConfiguration {
+        fileprivate let expression: String
+        public let limitCount: Int
     }
     
-    public static func validate(data: String, pattern: RegexPattern) -> Bool {
-        data.range(of: pattern.rawValue, options: .regularExpression) != nil
+    public var configuration: RegexConfiguration {
+        switch self {
+        case .nickname:
+            return .init(expression: "^[0-9a-zA-Z가-힣]{1,8}$", limitCount: 8)
+        case .topicTitle:
+            return .init(expression: "^[0-9a-zA-Z가-힣!@#$%^()]{1,20}$", limitCount: 20)
+        case .topicKeyword:
+            return .init(expression: "^[0-9a-zA-Z가-힣]{1,6}$", limitCount: 6)
+        case .choiceContent:
+            return .init(expression: "^[0-9a-zA-Z가-힣!@#$%^()]{1,25}$", limitCount: 25)
+        }
     }
 }

--- a/Projects/Features/MyPageFeature/Interface/ViewModel/ModifyUserInformationViewModel.swift
+++ b/Projects/Features/MyPageFeature/Interface/ViewModel/ModifyUserInformationViewModel.swift
@@ -47,7 +47,6 @@ public protocol ModifyUserInformationViewModelInput {
 }
 
 public protocol ModifyUserInformationViewModelOutput {
-    var nicknameLimitCount: Int { get }
     var nicknameVerification: PassthroughSubject<Verification, Never> { get }
     var jobSubject: PassthroughSubject<Job, Never> { get }
     var canMove: CurrentValueSubject<Bool, Never> { get }

--- a/Projects/Features/MyPageFeature/Sources/ViewController/ModifyUserInformationViewController.swift
+++ b/Projects/Features/MyPageFeature/Sources/ViewController/ModifyUserInformationViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 import MyPageFeatureInterface
 import FeatureDependency
 import Domain
+import Core
 
 final class ModifyUserInformationViewController: BaseViewController<NavigateHeaderView, ModifyUserInformationView, DefaultMyPageCoordinator> {
     
@@ -48,7 +49,7 @@ final class ModifyUserInformationViewController: BaseViewController<NavigateHead
         }
         
         func nicknameLimitCount() {
-            mainView.nicknameView.contentView.limitCount = viewModel.nicknameLimitCount
+            mainView.nicknameView.contentView.limitCount = Regex.nickname.limitCount
         }
     }
     

--- a/Projects/Features/MyPageFeature/Sources/ViewModel/DefaultModifyUserInformationViewModel.swift
+++ b/Projects/Features/MyPageFeature/Sources/ViewModel/DefaultModifyUserInformationViewModel.swift
@@ -28,8 +28,6 @@ final class DefaultModifyUserInformationViewModel: BaseViewModel, ModifyUserInfo
     let canMove: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
     let errorHandler: PassthroughSubject<ErrorContent, Never> = PassthroughSubject()
     
-    let nicknameLimitCount: Int = 8
-    
     var successRegister: (() -> Void)?
     
     private var requestValue: ModifyMemberInformationUseCaseRequestValue?

--- a/Projects/Features/MyPageFeature/Sources/ViewModel/DefaultModifyUserInformationViewModel.swift
+++ b/Projects/Features/MyPageFeature/Sources/ViewModel/DefaultModifyUserInformationViewModel.swift
@@ -44,15 +44,10 @@ final class DefaultModifyUserInformationViewModel: BaseViewModel, ModifyUserInfo
                 self.nicknameVerification.send(verification())
                 
                 func verification() -> Verification {
-                    if nickname.count > self.nicknameLimitCount || nickname.count == 0 {
-                        return .init(data: nickname, isValid: false, errorMessage: "* 글자 수 초과")
-                    }
-                    else if !Regex.validate(data: nickname, pattern: .nickname) {
-                        return .init(data: nickname, isValid: false, errorMessage: "* 한글, 영문, 숫자만 가능해요.")
-                    }
-                    else {
+                    if Regex.validate(data: nickname, pattern: .nickname) {
                         return .init(data: nickname, isValid: true, errorMessage: nil)
                     }
+                    return .init(data: nickname, isValid: false, errorMessage: "* 한글, 영문, 숫자만 가능해요.")
                 }
             }
             .store(in: &cancellable)

--- a/Projects/Features/OnboardingFeature/Interface/ViewModel/SignUpViewModel.swift
+++ b/Projects/Features/OnboardingFeature/Interface/ViewModel/SignUpViewModel.swift
@@ -37,7 +37,6 @@ public struct SignUpViewModelInputValue {
 }
 
 public protocol SignUpViewModelOutput {
-    var nicknameLimitCount: Int { get }
     var birthdayLimitCount: Int { get }
     ///닉네임의 유효성과 닉네임이 유효하지 않은 경우의 에러 메시지를 방출
     var nicknameValidation: PassthroughSubject<(Bool, String?), Never> { get }

--- a/Projects/Features/OnboardingFeature/Sources/ViewController/SignUpViewController.swift
+++ b/Projects/Features/OnboardingFeature/Sources/ViewController/SignUpViewController.swift
@@ -45,7 +45,7 @@ public final class SignUpViewController: BaseViewController<BaseHeaderView, Sign
         }
         
         func setNicknameLimitCount() {
-            mainView.nicknameView.contentView.limitCount = viewModel.nicknameLimitCount
+            mainView.nicknameView.contentView.limitCount = Regex.nickname.limitCount
         }
     }
 

--- a/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultSignUpViewModel.swift
+++ b/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultSignUpViewModel.swift
@@ -53,19 +53,13 @@ extension DefaultSignUpViewModel {
                 self.nicknameValidation.send(validation())
                 
                 func validation() -> (Bool, String?) {
-                    if nickname.count > self.nicknameLimitCount || nickname.count == 0 {
-                        return (false, "* 글자 수 초과")
-                    }
-                    else if !Regex.validate(data: nickname, pattern: .nickname) {
-                        return (false, "* 한글, 영문, 숫자만 가능해요.")
-                    }
-                    else {
+                    if Regex.validate(data: nickname, pattern: .nickname) {
                         return (true, nil)
                     }
+                    return (false, "* 한글, 영문, 숫자만 가능해요.")
                 }
             }
             .store(in: &cancellable)
-        
         
         input.birthdayEditingEnd
             .sink{ [weak self] birthday in

--- a/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultSignUpViewModel.swift
+++ b/Projects/Features/OnboardingFeature/Sources/ViewModel/DefaultSignUpViewModel.swift
@@ -33,7 +33,6 @@ public final class DefaultSignUpViewModel: BaseViewModel, SignUpViewModel {
     public let birthdayValidation: PassthroughSubject<(Bool, String?), Never> = PassthroughSubject()
     
     public let jobs: [Job] = Job.allCases
-    public let nicknameLimitCount: Int = 8
     public let birthdayLimitCount: Int = 8
     
     public var moveNext: (() -> Void)?

--- a/Projects/Features/TopicGenerateFeature/Demo/SceneDelegate.swift
+++ b/Projects/Features/TopicGenerateFeature/Demo/SceneDelegate.swift
@@ -7,8 +7,8 @@
 //
 
 import UIKit
-import TopicFeatureInterface
-import TopicFeature
+import TopicGenerateFeatureInterface
+import TopicGenerateFeature
 import FeatureDependency
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/Projects/Features/TopicGenerateFeature/Interface/ViewModel/TopicGenerateViewModel.swift
+++ b/Projects/Features/TopicGenerateFeature/Interface/ViewModel/TopicGenerateViewModel.swift
@@ -58,19 +58,8 @@ public protocol TopicGenerateBSideViewModelOutput {
 public protocol TopicGenerateViewModelOutput {
     var topicSide: CurrentValueSubject<Topic.Side, Never> { get }
     var recommendKeywords: [String] { get }
-    var limitCount: TopicGenerateTextLimitCount { get }
     func otherTopicSide() -> Topic.Side
     var successRegister: (() -> Void)? { get set }
-}
-
-public struct TopicGenerateTextLimitCount {
-    
-    public init() { }
-    
-    public let title: Int = 20
-    public let keyword: Int = 6
-    public let textOption: Int = 25
-    public let imageComment: Int = 12
 }
 
 public struct TopicGenerateContentViewModelInputValue {

--- a/Projects/Features/TopicGenerateFeature/Sources/ViewController/Generate/BsideTopicGenerateViewController.swift
+++ b/Projects/Features/TopicGenerateFeature/Sources/ViewController/Generate/BsideTopicGenerateViewController.swift
@@ -74,7 +74,7 @@ final class BsideTopicGenerateViewController: BaseViewController<TopicGenerateHe
         }
         
         func limitCount() {
-            mainView.textContentView.setLimitCount(viewModel.limitCount.textOption)
+            mainView.textContentView.setLimitCount(Regex.choiceContent.limitCount)
         }
         
         func addSwitchTarget() {

--- a/Projects/Features/TopicGenerateFeature/Sources/ViewController/Generate/TopicGenerateViewController.swift
+++ b/Projects/Features/TopicGenerateFeature/Sources/ViewController/Generate/TopicGenerateViewController.swift
@@ -12,6 +12,7 @@ import ABKit
 import TopicGenerateFeatureInterface
 import FeatureDependency
 import Domain
+import Core
 
 final class TopicGenerateViewController: BaseViewController<TopicGenerateHeaderView, BaseView, DefaultTopicGenerateCoordinator> {
     
@@ -74,12 +75,12 @@ final class TopicGenerateViewController: BaseViewController<TopicGenerateHeaderV
             .store(in: &cancellables)
         
         func setLimitCount() {
-            aSideView.titleSection.contentView.limitCount = viewModel.limitCount.title
-            aSideView.optionsSection.contentView.aTextField.limitCount = viewModel.limitCount.textOption
-            aSideView.optionsSection.contentView.bTextField.limitCount = viewModel.limitCount.textOption
+            aSideView.titleSection.contentView.limitCount = Regex.topicTitle.limitCount
+            aSideView.optionsSection.contentView.aTextField.limitCount = Regex.choiceContent.limitCount
+            aSideView.optionsSection.contentView.bTextField.limitCount = Regex.choiceContent.limitCount
             
-            bSideView.titleSection.contentView.limitCount = viewModel.limitCount.title
-            bSideView.keywordSection.contentView.limitCount = viewModel.limitCount.keyword
+            bSideView.titleSection.contentView.limitCount = Regex.topicTitle.limitCount
+            bSideView.keywordSection.contentView.limitCount = Regex.topicKeyword.limitCount
         }
         
         func setHeaderViewTopicSide() {

--- a/Projects/Features/TopicGenerateFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
+++ b/Projects/Features/TopicGenerateFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
@@ -12,6 +12,7 @@ import FeatureDependency
 import Combine
 import Domain
 import UIKit
+import Core
 
 fileprivate struct ChoiceContentPublisherStorage {
     
@@ -78,14 +79,15 @@ final class DefaultTopicGenerateViewModel: BaseViewModel, TopicGenerateViewModel
     //MARK: Input
     
     private func validation(title: String) -> (Bool, String?) {
-        if title.count > 0 && title.count <= limitCount.title { //특수문자 조건 추가
+        print(title, Regex.validate(data: title, pattern: .topicTitle))
+        if Regex.validate(data: title, pattern: .topicTitle) {
             return (true, nil)
         }
         return (false, "* 특수문자는 !@#$%^()만 사용하실 수 있습니다.")
     }
     
     private func validation(option: String) -> (Bool, String?) {
-        if option.count > 0 && option.count <= limitCount.textOption { //특수문자 조건 추가
+        if Regex.validate(data: option, pattern: .choiceContent) {
             return (true, nil)
         }
         return (false, "* 특수문자는 !@#$%^()만 사용하실 수 있습니다.")
@@ -140,7 +142,7 @@ final class DefaultTopicGenerateViewModel: BaseViewModel, TopicGenerateViewModel
                 self.sideBKeywordValidation.send(keywordValidation())
                 
                 func keywordValidation() -> (Bool, String?) {
-                    if keyword.count > 0 && keyword.count <= self.limitCount.keyword {
+                    if Regex.validate(data: keyword, pattern: .topicKeyword) {
                         return (true, nil)
                     }
                     return (false, "* 한글, 영문, 숫자만 사용하실 수 있습니다.")

--- a/Projects/Features/TopicGenerateFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
+++ b/Projects/Features/TopicGenerateFeature/Sources/ViewModel/DefaultTopicGenerateViewModel.swift
@@ -70,7 +70,6 @@ final class DefaultTopicGenerateViewModel: BaseViewModel, TopicGenerateViewModel
     let contentValidation: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
 
     let recommendKeywords: [String] = ["스포츠", "연예방송", "일상다반사", "게임", "일상다반사"]
-    let limitCount: TopicGenerateTextLimitCount = TopicGenerateTextLimitCount()
     
     func otherTopicSide() -> Topic.Side {
         Topic.Side.allCases.filter{ $0 != topicSide.value }.first!


### PR DESCRIPTION
### 텍스트 필드 글자 수 제한 프로퍼티 리팩토링
기존에는 ViewModel에서 글자 수 제한 프로퍼티를 선언해 각 ViewModel에서 관리했었습니다. 이를 한 곳에서 관리하기 위해 Regex 리팩토링을진행 및 limitCount 프로퍼티를 추가하였습니다. Regex는 원시값으로 정규표현식을 정의했었는데, 제한 글자수 데이터도 포함하기 위해 Configuration 구조체를 내부에 선언했습니다. 

### 텍스트 필드 입력값 정규표현식으로 점검
기존에 글자 수 점검만 진행했었는데, Regex를 활용해 정규표현식으로 점검하도록 변경하였습니다. 

### 커스텀 텍스트 필드 글자 수 초과시 입력 제한
커스텀 텍스트 필드 내부에 글자 수를 초과할 경우, 입력이 제한되는 기능을 추가하였습니다. 

---
close #153